### PR TITLE
Development from creation of HSF DAWG standardized examples

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -31,6 +31,7 @@ jobs:
     - name: Setup environment
       run: |
         sudo apt-get install graphviz libgraphviz-dev
+        sudo ln -s /usr/lib/x86_64-linux-gnu/libclang-6.0.so.1 /usr/lib/x86_64-linux-gnu/libclang.so
         python -m pip install --upgrade pip
         pip install virtualenv
         python -m virtualenv timber-env

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -30,7 +30,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Setup environment
       run: |
-        sudo apt-get install graphviz
+        sudo apt-get install graphviz libgraphviz-dev
         python -m pip install --upgrade pip
         pip install virtualenv
         python -m virtualenv timber-env

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -30,6 +30,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Setup environment
       run: |
+        sudo apt-get install graphviz
         python -m pip install --upgrade pip
         pip install virtualenv
         python -m virtualenv timber-env

--- a/TIMBER/Analyzer.py
+++ b/TIMBER/Analyzer.py
@@ -145,6 +145,21 @@ class analyzer(object):
         del RunChain
         self.ActiveNode = self.BaseNode
  
+    def Close(self):
+        print ('Deleting analyzer instance for %s'%self.fileName)
+        self.BaseNode.Close()
+        self.__eventsChain.Reset()
+
+    def __str__(self):
+        out = ''
+        for a in dir(self):
+            if not a.startswith('_') and not callable(getattr(self, a)):
+                if isinstance(getattr(self, a),list) and len(getattr(self, a))>0 and isinstance(getattr(self, a)[0],Node):
+                    out += '{:15s} = {}\n'.format(a,[n.name for n in getattr(self,a)])
+                else:
+                    out += '{:15s} = {}\n'.format(a,getattr(self,a))
+        return out
+
     @property
     def DataFrame(self):
         '''
@@ -280,7 +295,7 @@ class analyzer(object):
         Returns:
             str: File name
         '''
-        return self.__fileName
+        return self.fileName
 
     #------------------------------------------------------------#
     # Node operations - same as Node class methods but have      #
@@ -771,6 +786,28 @@ class Node(object):
         self.action = action
         self.children = children
         
+    def Close(self):
+        # print (self)
+        # print ('Deleting Node %s'%self.name)
+        # print (self.children)
+        for c in self.children:
+            # print ('Attempting to delete child %s'%c)
+            c.Close()
+        self.children = []
+        self.DataFrame = None
+        self.name = None
+        self.action = None
+
+    def __str__(self):
+        out = 'NODE:\n'
+        for a in dir(self):
+            if not a.startswith('__') and not callable(getattr(self, a)):
+                if a == 'children':
+                    out += '\t {:15s} = {}\n'.format(a,[c.name for c in getattr(self,a)])
+                else:
+                    out += '\t {:15s} = {}\n'.format(a,getattr(self,a))
+        return out[:-1]
+
     def Clone(self,name=''):
         '''Clones Node instance without child information and with new name if specified.
 

--- a/TIMBER/Analyzer.py
+++ b/TIMBER/Analyzer.py
@@ -1108,7 +1108,7 @@ class HistGroup(Group):
 
         '''
         # Book new group in case THmethod returns something
-        newGroup = Group(self.name+'_%s%s'%(THmethod,argsTuple))
+        newGroup = HistGroup(self.name+'_%s%s'%(THmethod,argsTuple))
         # Initialize check for None return type
         returnNone = False
         # Loop over hists
@@ -1122,6 +1122,19 @@ class HistGroup(Group):
 
         if returnNone: del newGroup
         else: return newGroup
+
+    def Merge(self):
+        '''Merge together the histograms in the group.
+
+        Returns:
+            TH1: Merged histogram.
+        '''
+        for ikey,key in enumerate(self.keys()):
+            if ikey == 0:
+                out = self[key].Clone(self.name)
+            else:
+                out.Add(self[key])
+        return out
 
 ####################
 # Correction class #

--- a/TIMBER/Analyzer.py
+++ b/TIMBER/Analyzer.py
@@ -14,8 +14,8 @@ pp = pprint.PrettyPrinter(indent=4)
 
 
 # For parsing c++ modules
-libs = subprocess.Popen('$ROOTSYS/bin/root-config --libs',shell=True, stdout=subprocess.PIPE).communicate()[0].strip()
-rootpath = subprocess.Popen('echo $ROOTSYS',shell=True, stdout=subprocess.PIPE).communicate()[0].strip()
+libs = subprocess.Popen('$ROOTSYS/bin/root-config --libs',shell=True, stdout=subprocess.PIPE, universal_newlines=True).communicate()[0].strip()
+rootpath = subprocess.Popen('echo $ROOTSYS',shell=True, stdout=subprocess.PIPE, universal_newlines=True).communicate()[0].strip()
 cpp_args =  '-x c++ -c --std=c++11 -I %s/include %s -lstdc++'%(rootpath,libs)
 cpp_args = cpp_args.split(' ')
 
@@ -489,7 +489,8 @@ class analyzer(object):
         commonVars = []
         for c in collections:
             out = []
-            for bname in self.DataFrame.GetColumnNames():
+            colNames = sorted([str(b) for b in self.DataFrame.GetColumnNames()])
+            for bname in colNames:
                 if c+'_' in str(bname):
                     out.append(str(bname).replace(c+'_',''))
             commonVars.append(out)
@@ -1231,7 +1232,7 @@ class Group(object):
         Returns:
             list: Names/keys from Group.
         '''
-        return self.items.keys()
+        return list(self.items.keys())
 
     def values(self):
         '''Gets list of values from Group.
@@ -1239,7 +1240,7 @@ class Group(object):
         Returns:
             list: Values from Group.
         '''
-        return self.items.values()
+        return list(self.items.values())
     
     def __setitem__(self, key, value):
         '''Set key-value pair as you would with dictionary.
@@ -1388,7 +1389,7 @@ class Correction(object):
         self.__script = self.__getScript(script)
         self.__setType(corrtype)
         self.__funcInfo = self.__getFuncInfo(mainFunc)
-        self.__mainFunc = self.__funcInfo.keys()[0]
+        self.__mainFunc = list(self.__funcInfo.keys())[0]
         self.__columnNames = LoadColumnNames() if columnList == None else columnList
         self.__constructor = constructor 
         self.__objectName = self.name
@@ -1606,7 +1607,7 @@ class Correction(object):
         Returns:
             [str]: List of possible function names found in C++ script.
         '''
-        return self.__funcInfo.keys()
+        return list(self.__funcInfo.keys())
 
 def LoadColumnNames(source=''):
     '''Loads column names from a text file.

--- a/TIMBER/Analyzer.py
+++ b/TIMBER/Analyzer.py
@@ -80,17 +80,17 @@ class analyzer(object):
         # Active node. Access via GetActiveNode(). Set via SetActiveNode().
 
         super(analyzer, self).__init__()
-        self.__fileName = fileName 
+        self.fileName = fileName 
         self.__eventsTreeName = eventsTreeName
 
         # Setup TChains for multiple or single file
         self.__eventsChain = ROOT.TChain(self.__eventsTreeName) 
         RunChain = ROOT.TChain(runTreeName) # Has generated event count information - will be deleted after initialization
-        if ".root" in self.__fileName: 
-            self.__eventsChain.Add(self.__fileName)
-            RunChain.Add(self.__fileName)
-        elif ".txt" in self.__fileName: 
-            txt_file = open(self.__fileName,"r")
+        if ".root" in self.fileName: 
+            self.__eventsChain.Add(self.fileName)
+            RunChain.Add(self.fileName)
+        elif ".txt" in self.fileName: 
+            txt_file = open(self.fileName,"r")
             for l in txt_file.readlines():
                 thisfile = l.strip()
                 if 'root://' not in thisfile and '/store/' in thisfile: thisfile='root://cms-xrd-global.cern.ch/'+thisfile
@@ -102,6 +102,7 @@ class analyzer(object):
         # Make base RDataFrame
         BaseDataFrame = ROOT.RDataFrame(self.__eventsChain) 
         self.BaseNode = Node('base',BaseDataFrame) 
+        self.BaseNode.children = [] # protect against memory issue when running over multiple sets in one script
         self.AllNodes = [] 
         self.Corrections = {} 
 

--- a/TIMBER/Analyzer.py
+++ b/TIMBER/Analyzer.py
@@ -459,7 +459,8 @@ class analyzer(object):
                         concat_str = 'Concatenate(%s,%s)'%(concat_str,collName+'_'+var)
 
                 self.Define(name+'_'+var,concat_str)
-            
+
+        self.Define('n'+name,'+'.join(['n'+n for n in collectionNames]))
 
         # for i in range(1,len(collectionNames)):
         #     collName = collectionNames[i]

--- a/TIMBER/Analyzer.py
+++ b/TIMBER/Analyzer.py
@@ -792,8 +792,6 @@ class Node(object):
         '''
         if overwrite: self.children = []
 
-        print ('Current children %s'%self.children)
-
         if isinstance(child,Node):
             if child.name not in [c.name for c in self.children]:
                 self.children.append(child)

--- a/TIMBER/Analyzer.py
+++ b/TIMBER/Analyzer.py
@@ -449,6 +449,49 @@ class analyzer(object):
             else:
                 self.Define(replacementName,'%s[%s]'%(b,name+'_idx'))
 
+    def MergeCollections(self,name,collectionNames):
+        vars_to_make = self.CommonVars(collectionNames)
+        for var in vars_to_make:
+            if 'RVec' in self.DataFrame.GetColumnType(collectionNames[0]+'_'+var):
+                concat_str = collectionNames[0]+'_'+var
+                for collName in collectionNames:
+                    if collName != collectionNames[0]:
+                        concat_str = 'Concatenate(%s,%s)'%(concat_str,collName+'_'+var)
+
+                self.Define(name+'_'+var,concat_str)
+            
+
+        # for i in range(1,len(collectionNames)):
+        #     collName = collectionNames[i]
+        #     self.Define(name+'_idx','Concatenate(%s,%s)'%(collectionNames[0],))
+        #     for b in collBranches:
+        #         replacementName = b.replace(basecoll,name)
+        #         if b == 'n'+basecoll:
+        #             self.Define(replacementName,'std::count(%s_idx.begin(), %s_idx.end(), 1)'%(name,name))
+        #         elif 'RVec' not in self.DataFrame.GetColumnType(b):
+        #             print ('Found type %s during SubCollection'%self.DataFrame.GetColumnType(b))
+        #             self.Define(replacementName,b)
+        #         else:
+        #             self.Define(replacementName,'%s[%s]'%(b,name+'_idx'))
+
+    def CommonVars(self,collections):
+        '''Find the common variables between collections.
+
+        @param collections ([str]): List of collections names (not branch names).
+
+        Returns:
+            [str]: List of variables shared among the collections.
+        '''
+        commonVars = []
+        for c in collections:
+            out = []
+            for bname in self.DataFrame.GetColumnNames():
+                if c+'_' in str(bname):
+                    out.append(str(bname).replace(c+'_',''))
+            commonVars.append(out)
+
+        return list(set.intersection(*map(set,commonVars)))
+
     #---------------------#
     # Corrections/Weights #
     #---------------------#

--- a/TIMBER/Analyzer.py
+++ b/TIMBER/Analyzer.py
@@ -1188,8 +1188,12 @@ class Group(object):
         Returns:
             Group: Addition of the two groups (will be VarGroup, CutGroup, or HistGroup if applicable).
         '''
-        added = copy.deepcopy(self.items)
-        added.update(other.items)
+        added = {}
+        for k in self.items.keys():
+            added[k] = self.items[k]
+        for k in other.items.keys():
+            added[k] = other.items[k]
+
         if self.type == 'var' and other.type == 'var': newGroup = VarGroup(self.name+"+"+other.name)
         elif self.type == 'cut' and other.type == 'cut': newGroup = CutGroup(self.name+"+"+other.name)
         elif self.type == 'hist' and other.type == 'hist': newGroup = HistGroup(self.name+"+"+other.name)

--- a/TIMBER/Analyzer.py
+++ b/TIMBER/Analyzer.py
@@ -307,7 +307,7 @@ class analyzer(object):
         Will add the resulting node to tracking and set it as the #ActiveNode.
 
         @param name (str): Name for the cut for internal tracking and later reference.
-        @param cuts (str, CutGroup): A one-line C++ string that evaluates as a boolean or a CutGroup object which contains multiple actions that evaluate as booleans.
+        @param cuts (str, CutGroup): A one-line C++ string that evaluates as a bool or a CutGroup object which contains multiple actions that evaluate as bools.
         @param node (Node, optional): Node on which to apply the cut/filter. Defaults to #ActiveNode.
         @param nodetype (str, optional): Defaults to None in which case the new Node will
             be type "Define".
@@ -407,7 +407,7 @@ class analyzer(object):
         '''Forks a node based upon a discriminator being True or False (#ActiveNode by default).
 
         @param name (str): Name for the discrimination for internal tracking and later reference.
-        @param discriminator (str): A one-line C++ string that evaluates as a boolean to discriminate for the forking of the node.
+        @param discriminator (str): A one-line C++ string that evaluates as a bool to discriminate for the forking of the node.
         @param node (Node, optional): Node to discriminate. Must be of type Node (not RDataFrame). Defaults to #ActiveNode.
         @param passAsActiveNode (bool, optional): True if the #ActiveNode should be set to the node that passes the discriminator.
                 False if the #ActiveNode should be set to the node that fails the discriminator. Defaults to None in which case the #ActiveNode does not change.
@@ -834,14 +834,15 @@ class analyzer(object):
         dot.draw(outfilename)
 
     def MakeHistsWithBinning(self,histDict,name='',weight=None):
-        '''Batch creates histograms at the current #ActiveNode based on the input histDict
-        which is formated as `{[<column name>]: <binning tuple>}` where `[<column name>]` is a list
+        '''
+        Batch creates histograms at the current #ActiveNode based on the input `histDict`
+        which is formatted as `{[<column name>]: <binning tuple>}` where `[<column name>]` is a list
         of column names that you'd like to plot against each other in [x,y,z] order and `binning_tuple` is
-        the set of arguments that would normally be passed to `TH1`. The dimensionality of the returned histogram
-        is determined based on the size of `[<column name>]`.
+        the set of arguments that would normally be passed to `TH1`. The dimensions of the returned
+        histograms are determined based on the size of `[<column name>]`.
 
-        @param histDict ({std:tuple}): formated as `{<column name>: <binning tuple>}` where `binning_tuple` are
-            the arguments that would normally be passed to `TH1`. Size determines dimensionality of histogram.
+        @param histDict ({std:tuple}): formatted as `{<column name>: <binning tuple>}` where `binning_tuple` are
+            the arguments that would normally be passed to `TH1`. Size determines dimension of histogram.
         @param name (str, optional): Name for the output HistGroup. Defaults to '' in which case the name of the 
             #ActiveNode will be used.
         @param weight (str, optional): Weight (as a string) to apply to all histograms. Defaults to None.
@@ -1001,7 +1002,7 @@ class Node(object):
                 else:
                     raise TypeError('Child is not an instance of Node class for node %s' %self.name)
         else:
-            raise TypeError('Attempting to add chidren that are not in a list or dict.')
+            raise TypeError('Attempting to add children that are not in a list or dict.')
 
     def Define(self,name,var,nodetype=None):
         '''Produces a new Node with the provided variable/column added.
@@ -1041,7 +1042,7 @@ class Node(object):
         '''Produces a dictionary with two new Nodes made by forking this Node based upon a discriminator being True or False.
 
         @param name (str): Name for the discrimination for internal tracking and later reference.
-        @param discriminator (str): A one-line C++ string that evaluates as a boolean to discriminate on.
+        @param discriminator (str): A one-line C++ string that evaluates as a bool to discriminate on.
 
         Returns:
             dict: Dictionary with keys "pass" and "fail" corresponding to the passing and failing Nodes stored as values.
@@ -1418,7 +1419,7 @@ class Correction(object):
     def __setType(self,inType):
         '''Sets the type of correction.
         Will attempt to deduce from input script name if inType=''. File name
-        must have suffic '_weight' or '_SF' for weight type (correction plus uncertainties)
+        must have suffix '_weight' or '_SF' for weight type (correction plus uncertainties)
         or '_uncert' for 'uncert' type (only uncertainties).
 
         @param inType (str): Type of Correction. Use '' to deduce from input script name.
@@ -1510,7 +1511,7 @@ class Correction(object):
         '''Makes the call (stored in class instance) to the method with the branch/column names deduced or added from input.
 
         @param inArgs (list, optional): List of arguments (branch/column names) to provide to per-event evaluation method.
-                Defaults to [] in which case the arguements are deduced from what is written in the C++ script.
+                Defaults to [] in which case the arguments are deduced from what is written in the C++ script.
 
         Raises:
             NameError: If argument written in C++ script cannot be found in available columns.
@@ -1555,29 +1556,6 @@ class Correction(object):
         if self.__call == None:
             self.MakeCall(self, inArgs)
         return self.__call
-
-    # def SetMainFunc(self,funcname):
-    #     """Set the function to consider in the provided script.
-
-    #     Will check if funcname exists as a function in the script (can also provide a substring of the
-    #     desired function). If it does, sets the function to the matching one.
-
-    #     Returns:
-    #         Self with new function assigned.
-    #     """
-
-    #     # Find funcname in case it's abbreviated (which it might be if the user forgot the namespace)
-    #     full_funcname = ''
-    #     for f in self.__funcNames:
-    #         if funcname in f:
-    #             full_funcname = f
-    #             break
-
-    #     if full_funcname not in self.__funcNames:
-    #         raise ValueError('Function name "%s" is not defined for %s'%(funcname,self.__script))
-
-    #     self.__mainFunc = full_funcname
-    #     return self
 
     def GetMainFunc(self):
         '''Gets full main function name.

--- a/TIMBER/Analyzer.py
+++ b/TIMBER/Analyzer.py
@@ -450,6 +450,17 @@ class analyzer(object):
                 self.Define(replacementName,'%s[%s]'%(b,name+'_idx'))
 
     def MergeCollections(self,name,collectionNames):
+        '''Merge collections (provided by list of names in `collectionNames`) into
+        one called `name`. Only common variables are taken and stored in the new 
+        collection.
+
+        @param name (str): Name of new collection
+        @param collectionNames ([str]): List of names of collections to merge.
+
+        Example:
+            a = analyzer(<...>)
+            a.MergeCollections("Lepton",["Electron","Muon"])
+        '''
         vars_to_make = self.CommonVars(collectionNames)
         for var in vars_to_make:
             if 'RVec' in self.DataFrame.GetColumnType(collectionNames[0]+'_'+var):
@@ -461,19 +472,6 @@ class analyzer(object):
                 self.Define(name+'_'+var,concat_str)
 
         self.Define('n'+name,'+'.join(['n'+n for n in collectionNames]))
-
-        # for i in range(1,len(collectionNames)):
-        #     collName = collectionNames[i]
-        #     self.Define(name+'_idx','Concatenate(%s,%s)'%(collectionNames[0],))
-        #     for b in collBranches:
-        #         replacementName = b.replace(basecoll,name)
-        #         if b == 'n'+basecoll:
-        #             self.Define(replacementName,'std::count(%s_idx.begin(), %s_idx.end(), 1)'%(name,name))
-        #         elif 'RVec' not in self.DataFrame.GetColumnType(b):
-        #             print ('Found type %s during SubCollection'%self.DataFrame.GetColumnType(b))
-        #             self.Define(replacementName,b)
-        #         else:
-        #             self.Define(replacementName,'%s[%s]'%(b,name+'_idx'))
 
     def CommonVars(self,collections):
         '''Find the common variables between collections.
@@ -1005,7 +1003,6 @@ class Node(object):
                 raise TypeError("Group %s does not have a defined type. Please initialize with either CutGroup or VarGroup." %ag.name)                
 
         return node
-
 
     # IMPORTANT: When writing a variable size array through Snapshot, it is required that the column indicating its size is also written out and it appears before the array in the columns list.
     # columns should be an empty string if you'd like to keep everything

--- a/TIMBER/Analyzer.py
+++ b/TIMBER/Analyzer.py
@@ -423,6 +423,32 @@ class analyzer(object):
 
         return newNodes
 
+    def SubCollection(self,name,basecoll,condition,skip=[]):
+        '''Creates a collection of a current collection (from a NanoAOD-like format)
+        where the array-type branch is slimmed based on some selection.
+
+        @param name (str): Name of new collection.
+        @param basecoll (str): Name of derivative collection.
+        @param condition (str): C++ condition that determines which items
+
+        Returns:
+            None. New nodes created with the sub collection.
+
+        Example:
+            SubCollection('TopJets','FatJet','FatJet_msoftdrop > 105 && FatJet_msoftdrop < 220')
+        '''
+        collBranches = [str(cname) for cname in self.DataFrame.GetColumnNames() if basecoll in str(cname) and str(cname) not in skip]
+        self.Define(name+'_idx','%s'%(condition))
+        for b in collBranches:
+            replacementName = b.replace(basecoll,name)
+            if b == 'n'+basecoll:
+                self.Define(replacementName,'std::count(%s_idx.begin(), %s_idx.end(), 1)'%(name,name))
+            elif 'RVec' not in self.DataFrame.GetColumnType(b):
+                print ('Found type %s during SubCollection'%self.DataFrame.GetColumnType(b))
+                self.Define(replacementName,b)
+            else:
+                self.Define(replacementName,'%s[%s]'%(b,name+'_idx'))
+
     #---------------------#
     # Corrections/Weights #
     #---------------------#

--- a/TIMBER/Framework/include/common.h
+++ b/TIMBER/Framework/include/common.h
@@ -23,6 +23,32 @@ namespace analyzer {
         return result;
     }
 
+    RVec<RVec<float>> DeltaRCollections(RVec<float> eta0, RVec<float> eta1, RVec<float> phi0, RVec<float> phi1) {
+        /** Takes in two collections of eta and phi and calcualtes DeltaR for each permutations.
+         *  Returns vector of vectors - 
+         * { {float_00, float_01, float_02},
+         *   {float_10, float_11, float_12},
+         *   {float_20, float_21, float_22}
+         * } where float_ij represents the DeltaR value for the given permutation.
+         * Example of manipulating output:
+         *      Any()
+         */
+        int size0 = eta0.size();
+        int size1 = eta1.size();
+        RVec<float> dR;
+        RVec<RVec<float>> out;
+
+        for (int i = 0; i < size0; i++) {
+            dR.clear();
+            for (int j = 0; j < size1; j++) {
+                dR.push_back(ROOT::VecOps::DeltaR(eta0[i],eta1[j],phi0[i],phi1[j]));
+            }
+            out.push_back(dR);
+        }
+
+        return out;
+    }
+
     ROOT::Math::PtEtaPhiMVector TLvector(float pt,float eta,float phi,float m) {
         ROOT::Math::PtEtaPhiMVector v(pt,eta,phi,m);
         return v;

--- a/TIMBER/Framework/include/common.h
+++ b/TIMBER/Framework/include/common.h
@@ -23,32 +23,6 @@ namespace analyzer {
         return result;
     }
 
-    RVec<RVec<float>> DeltaRCollections(RVec<float> eta0, RVec<float> eta1, RVec<float> phi0, RVec<float> phi1) {
-        /** Takes in two collections of eta and phi and calcualtes DeltaR for each permutations.
-         *  Returns vector of vectors - 
-         * { {float_00, float_01, float_02},
-         *   {float_10, float_11, float_12},
-         *   {float_20, float_21, float_22}
-         * } where float_ij represents the DeltaR value for the given permutation.
-         * Example of manipulating output:
-         *      Any()
-         */
-        int size0 = eta0.size();
-        int size1 = eta1.size();
-        RVec<float> dR;
-        RVec<RVec<float>> out;
-
-        for (int i = 0; i < size0; i++) {
-            dR.clear();
-            for (int j = 0; j < size1; j++) {
-                dR.push_back(ROOT::VecOps::DeltaR(eta0[i],eta1[j],phi0[i],phi1[j]));
-            }
-            out.push_back(dR);
-        }
-
-        return out;
-    }
-
     ROOT::Math::PtEtaPhiMVector TLvector(float pt,float eta,float phi,float m) {
         ROOT::Math::PtEtaPhiMVector v(pt,eta,phi,m);
         return v;

--- a/TIMBER/Framework/include/common.h
+++ b/TIMBER/Framework/include/common.h
@@ -28,6 +28,19 @@ namespace analyzer {
         return v;
     }
 
+    RVec<ROOT::Math::PtEtaPhiMVector> TLvector(RVec<float> pt,RVec<float> eta,RVec<float> phi,RVec<float> m) {
+        RVec<ROOT::Math::PtEtaPhiMVector> vs;
+        for (int i = 0; i < pt.size(); i++) {
+            ROOT::Math::PtEtaPhiMVector v(pt[i],eta[i],phi[i],m[i]);
+            vs.push_back(v);
+        }
+        return vs;
+    }
+
+    float transverseMass(float MET_pt, float obj_pt, float MET_phi, float obj_phi) {
+        return sqrt(2.0*MET_pt*obj_pt-(1-cos(deltaPhi(MET_phi,obj_phi))));
+    }
+
     double invariantMass(ROOT::Math::PtEtaPhiMVector v1, ROOT::Math::PtEtaPhiMVector v2) {
         return (v1+v2).M();
     }

--- a/TIMBER/Tools/Common.py
+++ b/TIMBER/Tools/Common.py
@@ -161,28 +161,28 @@ def AsciiEncodeDict(data):
     ascii_encode = lambda x: x.encode('ascii') if isinstance(x, unicode) else x 
     return dict(map(ascii_encode, pair) for pair in data.items())
 
-def ConcatCols(self,colnames,val='1',connector='&&'):
-        '''Concatenates a list of column names evaluating to a common `val` (usually 1 or 0) 
-        with some `connector` (bool logic operator).
+def ConcatCols(colnames,val='1',connector='&&'):
+    '''Concatenates a list of column names evaluating to a common `val` (usually 1 or 0) 
+    with some `connector` (bool logic operator).
 
-        @param colnames ([str]): List of column names.
-        @param val (str): Value to test equality of all columns. Defaults to '1'.
-        @param connector (str): C++ bool logic operator between column equality checks. Defaults to '&&'.
+    @param colnames ([str]): List of column names.
+    @param val (str): Value to test equality of all columns. Defaults to '1'.
+    @param connector (str): C++ bool logic operator between column equality checks. Defaults to '&&'.
 
-        Returns:
-            str: Concatenated string of the entire evaluation that in C++ will return a bool.
-        '''
-        concat = ''
-        for i,c in enumerate(colnames):
-            if concat == '': 
-                concat = '((%s==%s)'%(c,val)
-            else: 
-                concat += ' %s (%s==%s)'%(connector,c,val)
+    Returns:
+        str: Concatenated string of the entire evaluation that in C++ will return a bool.
+    '''
+    concat = ''
+    for c in colnames:
+        if concat == '': 
+            concat = '((%s==%s)'%(c,val)
+        else: 
+            concat += ' %s (%s==%s)'%(connector,c,val)
 
-        if concat != '': 
-            concat += ')' 
-            
-        return concat
+    if concat != '': 
+        concat += ')' 
+        
+    return concat
 
 def GetHistBinningTuple(h):
     '''Gets the binning information for a histogram and returns it 

--- a/TIMBER/Tools/Common.py
+++ b/TIMBER/Tools/Common.py
@@ -163,11 +163,11 @@ def AsciiEncodeDict(data):
 
 def ConcatCols(self,colnames,val='1',connector='&&'):
         '''Concatenates a list of column names evaluating to a common `val` (usually 1 or 0) 
-        with some `connector` (boolean logic operator).
+        with some `connector` (bool logic operator).
 
         @param colnames ([str]): List of column names.
         @param val (str): Value to test equality of all columns. Defaults to '1'.
-        @param connector (str): C++ boolean logic operator between column equality checks. Defaults to '&&'.
+        @param connector (str): C++ bool logic operator between column equality checks. Defaults to '&&'.
 
         Returns:
             str: Concatenated string of the entire evaluation that in C++ will return a bool.
@@ -186,7 +186,7 @@ def ConcatCols(self,colnames,val='1',connector='&&'):
 
 def GetHistBinningTuple(h):
     '''Gets the binning information for a histogram and returns it 
-    as a tuple ordered like the arguements to construct a new histogram.
+    as a tuple ordered like the arguments to construct a new histogram.
     Supports TH1, TH2, and TH3.
 
     @param h (TH1): Input histogram from which to get the binning information.
@@ -195,7 +195,7 @@ def GetHistBinningTuple(h):
         TypeError: If histogram does not derive from TH1.
 
     Returns:
-        tuple(tuple, int): First element of return is the binning and the second element is the dimensionality.
+        tuple(tuple, int): First element of return is the binning and the second element is the dimension.
     '''
     # At least 1D (since TH2 and TH3 inherit from TH1)
     if isinstance(h,ROOT.TH1):
@@ -272,7 +272,7 @@ def DictStructureCopy(inDict):
     newDict = {}
     for k1,v1 in inDict.items():
         if type(v1) == dict:
-            newDict[k1] = dictStructureCopy(v1)
+            newDict[k1] = DictStructureCopy(v1)
         else:
             newDict[k1] = 0
     return newDict
@@ -288,7 +288,7 @@ def DictCopy(inDict):
     newDict = {}
     for k1,v1 in inDict.items():
         if type(v1) == dict:
-            newDict[k1] = dictCopy(v1)
+            newDict[k1] = DictCopy(v1)
         else:
             newDict[k1] = v1
     return newDict

--- a/TIMBER/Tools/Common.py
+++ b/TIMBER/Tools/Common.py
@@ -3,7 +3,7 @@ Commonly used functions available for use that can be generic or TIMBER specific
 @{
 '''
 
-import json, ROOT, os, subprocess
+import json, ROOT, os, subprocess, TIMBER
 from ROOT import RDataFrame
 from TIMBER.Tools.CMS import CMS_lumi, tdrstyle
 from contextlib import contextmanager
@@ -79,7 +79,7 @@ def StitchQCD(QCDdict,normDict=None):
             for hkey in QCDdict[k].keys():
                 QCDdict[k][hkey].Scale(normDict[k])
     # Stitch
-    out = HistGroup("QCD")
+    out = TIMBER.Analyzer.HistGroup("QCD")
     for ksample in QCDdict.keys(): 
         for khist in QCDdict[ksample].keys():
             if khist not in out.keys():

--- a/benchmark/ex.cc
+++ b/benchmark/ex.cc
@@ -1,0 +1,33 @@
+#include "TIMBER/Framework/include/common.h"
+#include "ROOT/RVec.hxx"
+#include <Math/Vector4Dfwd.h>
+#include <Math/GenVector/LorentzVector.h>
+using namespace ROOT::VecOps;
+
+// For ex5.py and ex6.py
+// Muon pair mass for all combinations of muons with opposite sign
+RVec<float> InvMassOppMuMu (RVec<float> Muon_pt, RVec<float> Muon_eta, RVec<float> Muon_phi, RVec<float> Muon_mass, RVec<float> Muon_charge) {
+    int nMuon = Muon_pt.size();
+    int mu0idx, mu1idx;
+    ROOT::Math::PtEtaPhiMVector mu0LV;
+    ROOT::Math::PtEtaPhiMVector mu1LV; 
+    RVec<RVec<int>> comboIdxs = Combinations(Muon_pt,2);
+    RVec<float> invMass;
+
+    for (int i = 0; i < comboIdxs[0].size(); i++) {
+        mu0idx = comboIdxs[0][i];
+        mu1idx = comboIdxs[1][i];
+
+        if (Muon_charge[mu0idx] != Muon_charge[mu1idx]) {
+            mu0LV.SetCoordinates(Muon_pt[mu0idx], Muon_eta[mu0idx], Muon_phi[mu0idx], Muon_mass[mu0idx]);
+            mu1LV.SetCoordinates(Muon_pt[mu1idx], Muon_eta[mu1idx], Muon_phi[mu1idx], Muon_mass[mu1idx]);
+            invMass.push_back((mu0LV+mu1LV).M());
+        }
+    }
+    
+    return invMass;
+}
+
+RVec<float> CloseLepVeto () {
+    
+}

--- a/benchmark/ex.cc
+++ b/benchmark/ex.cc
@@ -45,3 +45,20 @@ RVec<float> CloseLepVeto (RVec<float> Lepton_pt, RVec<float> Lepton_eta, RVec<fl
     }
     return jet_bool_vect;
 }
+
+int NonZlep(RVec<ROOT::Math::PtEtaPhiMVector> Lepton_vect, RVec<int> Lepton_pdgId, RVec<int> Lepton_charge) {
+    RVec<RVec<int>> combos = Combinations(Lepton_vect,3); // build combinations where first two are the Z
+    int NonZlep_idx = -1;
+    float deltaMZ = 1000.; // start at large value for comparison
+    float dMZ;
+    bool sameFlavOppSign;
+    for (int i = 0; i < combos[0].size(); i++) { // loop over combinations
+        dMZ = abs(91.2-(Lepton_vect[combos[0][i]]+Lepton_vect[combos[1][i]]).M());
+        sameFlavOppSign = (Lepton_pdgId[combos[0][i]] == -1*Lepton_pdgId[combos[1][i]]);
+        if ((dMZ < deltaMZ) && sameFlavOppSign) {
+            deltaMZ = dMZ;
+            NonZlep_idx = combos[2][i];
+        }
+    }
+    return NonZlep_idx;
+}

--- a/benchmark/ex.cc
+++ b/benchmark/ex.cc
@@ -28,6 +28,20 @@ RVec<float> InvMassOppMuMu (RVec<float> Muon_pt, RVec<float> Muon_eta, RVec<floa
     return invMass;
 }
 
-RVec<float> CloseLepVeto () {
-    
+// (Lepton_pt > 10) && (analyzer::DeltaR(Lepton_eta, Jet_eta, Lepton_phi, Jet_phi) < 0.4)
+RVec<float> CloseLepVeto (RVec<float> Lepton_pt, RVec<float> Lepton_eta, RVec<float> Lepton_phi, RVec<float> Jet_eta, RVec<float> Jet_phi) {
+    RVec<bool> jet_bool_vect;
+    bool bool_pt, bool_deltaR, found_lep;
+    for (int ijet = 0; ijet < Jet_eta.size(); ijet++) {
+        found_lep = false;
+        for (int ilep = 0; ilep < Lepton_pt.size(); ilep++) {
+            bool_pt = Lepton_pt[ilep] > 10;
+            bool_deltaR = DeltaR(Lepton_eta[ilep], Jet_eta[ijet], Lepton_phi[ilep], Jet_phi[ijet]) < 0.4;
+            if (bool_pt && bool_deltaR){
+                found_lep = true;
+            }
+        }
+        jet_bool_vect.push_back(found_lep);
+    }
+    return jet_bool_vect;
 }

--- a/benchmark/ex1.py
+++ b/benchmark/ex1.py
@@ -1,0 +1,10 @@
+'''Plotting the Missing ET (or any event level variable).'''
+import time
+start = time.time()
+#---------------------
+from TIMBER.Analyzer import analyzer
+a = analyzer('examples/GluGluToHToTauTau_full.root')
+h = a.DataFrame.Histo1D('MET_pt')
+h.Draw('hist e')
+#---------------------
+print ('%s secs'%(time.time() - start))

--- a/benchmark/ex2.py
+++ b/benchmark/ex2.py
@@ -1,0 +1,10 @@
+'''Plotting the Jet pT (or any variable that is a per-event array).'''
+import time
+start = time.time()
+#---------------------
+from TIMBER.Analyzer import analyzer, HistGroup
+a = analyzer('examples/GluGluToHToTauTau_full.root')
+h = a.DataFrame.Histo1D('Jet_pt')
+h.Draw('hist e')
+#---------------------
+print ('%s secs'%(time.time() - start))

--- a/benchmark/ex3.py
+++ b/benchmark/ex3.py
@@ -1,0 +1,11 @@
+'''Plotting the Jet pT for jets that have a jet pT > 20 GeV and abs(jet eta) < 1.0.'''
+import time
+start = time.time()
+#---------------------
+from TIMBER.Analyzer import analyzer, HistGroup
+a = analyzer('examples/GluGluToHToTauTau_full.root')
+a.Define('JetSel_pt','Jet_pt[abs(Jet_eta) < 2.4]')
+h = a.DataFrame.Histo1D('JetSel_pt')
+h.Draw('hist e')
+#---------------------
+print ('%s secs'%(time.time() - start))

--- a/benchmark/ex4.py
+++ b/benchmark/ex4.py
@@ -1,0 +1,11 @@
+'''Plotting the Missing ET for jets[sic?] with at least 2 jets with Jet pT > 40 and abs(jet Eta) < 1.0'''
+import time
+start = time.time()
+#---------------------
+from TIMBER.Analyzer import analyzer
+a = analyzer('examples/GluGluToHToTauTau_full.root')
+a.Cut('twoHighPtJets','Sum(Jet_pt > 40 && abs(Jet_eta) < 1.0) >= 2')
+h = a.DataFrame.Histo1D('MET_pt')
+h.Draw('hist e')
+#---------------------
+print ('%s secs'%(time.time() - start))

--- a/benchmark/ex5.py
+++ b/benchmark/ex5.py
@@ -1,0 +1,15 @@
+'''Plot the opposite-sign muon pair mass for all combinations of muons'''
+import time
+start = time.time()
+#---------------------
+from TIMBER.Analyzer import analyzer
+from TIMBER.Tools.Common import CompileCpp
+CompileCpp('benchmark/ex.cc')
+
+a = analyzer('examples/GluGluToHToTauTau_full.root')
+a.Cut('twoMuons','nMuon>1')
+a.Define('invMassMuMu','InvMassOppMuMu(Muon_pt, Muon_eta, Muon_phi, Muon_mass, Muon_charge)')
+h = a.DataFrame.Histo1D(('invMassMuMu','Invariant mass of opposite sign muon pairs',100,0,200),'invMassMuMu')
+h.Draw('hist e')
+#---------------------
+print ('%s secs'%(time.time() - start))

--- a/benchmark/ex6.py
+++ b/benchmark/ex6.py
@@ -1,0 +1,17 @@
+'''Plot the Missing ET for events that have an opposite-sign muon pair mass in the range 60-120 GeV (double loop over single collection, math)'''
+import time
+start = time.time()
+#---------------------
+from TIMBER.Analyzer import analyzer
+from TIMBER.Tools.Common import CompileCpp
+CompileCpp('benchmark/ex.cc')
+
+a = analyzer('examples/GluGluToHToTauTau_full.root')
+a.Cut('twoMuons','nMuon>1')
+a.Define('invMassMuMu','InvMassOppMuMu(Muon_pt, Muon_eta, Muon_phi, Muon_mass, Muon_charge)')
+a.Cut('invMassMuMu_cut','Any(invMassMuMu > 60 && invMassMuMu < 120)')
+h = a.DataFrame.Histo1D('MET_pt')
+h.Draw('hist e')
+#---------------------
+print ('%s secs'%(time.time() - start))
+input('')

--- a/benchmark/ex6.py
+++ b/benchmark/ex6.py
@@ -1,4 +1,5 @@
-'''Plot the Missing ET for events that have an opposite-sign muon pair mass in the range 60-120 GeV (double loop over single collection, math)'''
+'''Plot the Missing ET for events that have an opposite-sign muon
+pair mass in the range 60-120 GeV (double loop over single collection, math)'''
 import time
 start = time.time()
 #---------------------
@@ -14,4 +15,3 @@ h = a.DataFrame.Histo1D('MET_pt')
 h.Draw('hist e')
 #---------------------
 print ('%s secs'%(time.time() - start))
-input('')

--- a/benchmark/ex7.py
+++ b/benchmark/ex7.py
@@ -12,9 +12,7 @@ nearLep = 'CloseLepVeto (Lepton_pt, Lepton_eta, Lepton_phi, Jet_eta, Jet_phi)'
 a.Define('goodJet_pt','Jet_pt[!(%s)]'%nearLep)
 a.Define('goodJet_pt30','goodJet_pt[goodJet_pt > 30]')
 a.Define('PtSum','Sum(goodJet_pt30)')
-print a.DataFrame.GetColumnType('PtSum')
 h = a.DataFrame.Histo1D('PtSum')
 h.Draw('hist e')
 #---------------------
 print ('%s secs'%(time.time() - start))
-input('')

--- a/benchmark/ex7.py
+++ b/benchmark/ex7.py
@@ -6,7 +6,7 @@ from TIMBER.Analyzer import analyzer
 from TIMBER.Tools.Common import CompileCpp
 CompileCpp('benchmark/ex.cc')
 
-a = analyzer('examples/ttbar16_sample.root')
+a = analyzer('examples/ttbar16_sample.root') # GluGlu sample is incomplete and missing electrons - this is a private stand in that must be replaced to work
 a.MergeCollections("Lepton",["Electron","Muon"])
 nearLep = 'CloseLepVeto (Lepton_pt, Lepton_eta, Lepton_phi, Jet_eta, Jet_phi)'
 a.Define('goodJet_pt','Jet_pt[!(%s)]'%nearLep)

--- a/benchmark/ex7.py
+++ b/benchmark/ex7.py
@@ -1,0 +1,21 @@
+'''Plot the sum of the pT of jets with pT > 30 GeV that are not within 0.4 from any lepton with pt > 10 GeV (looping over two collections)'''
+import time
+start = time.time()
+#---------------------
+from TIMBER.Analyzer import analyzer
+from TIMBER.Tools.Common import CompileCpp
+CompileCpp('TIMBER/Framework/include/common.h')
+
+a = analyzer('examples/ttbar16_sample.root')
+a.Define('Jet_pt30','Jet_pt[Jet_pt > 30]')
+a.Define('Lepton_eta','Concatenate(Electron_eta,Muon_eta)')
+a.Define('Lepton_phi','Concatenate(Electron_phi,Muon_phi)')
+a.Define('Lepton_pt','Concatenate(Electron_pt,Muon_pt)')
+nearLep = '(Lepton_pt > 10) && (analyzer::DeltaR(Lepton_eta, Jet_eta, Lepton_phi, Jet_phi) < 0.4)'
+a.Define('goodJet_pt','Jet_pt30[!(%s)]'%nearLep)
+a.Define('PtSum','Sum(goodJet_pt)')
+print a.DataFrame.GetColumnType('PtSum')
+h = a.DataFrame.Histo1D('PtSum')
+h.Draw('hist e')
+#---------------------
+print ('%s secs'%(time.time() - start))

--- a/benchmark/ex7.py
+++ b/benchmark/ex7.py
@@ -4,18 +4,17 @@ start = time.time()
 #---------------------
 from TIMBER.Analyzer import analyzer
 from TIMBER.Tools.Common import CompileCpp
-CompileCpp('TIMBER/Framework/include/common.h')
+CompileCpp('benchmark/ex.cc')
 
 a = analyzer('examples/ttbar16_sample.root')
-a.Define('Jet_pt30','Jet_pt[Jet_pt > 30]')
-a.Define('Lepton_eta','Concatenate(Electron_eta,Muon_eta)')
-a.Define('Lepton_phi','Concatenate(Electron_phi,Muon_phi)')
-a.Define('Lepton_pt','Concatenate(Electron_pt,Muon_pt)')
-nearLep = '(Lepton_pt > 10) && (analyzer::DeltaR(Lepton_eta, Jet_eta, Lepton_phi, Jet_phi) < 0.4)'
-a.Define('goodJet_pt','Jet_pt30[!(%s)]'%nearLep)
-a.Define('PtSum','Sum(goodJet_pt)')
+a.MergeCollections("Lepton",["Electron","Muon"])
+nearLep = 'CloseLepVeto (Lepton_pt, Lepton_eta, Lepton_phi, Jet_eta, Jet_phi)'
+a.Define('goodJet_pt','Jet_pt[!(%s)]'%nearLep)
+a.Define('goodJet_pt30','goodJet_pt[goodJet_pt > 30]')
+a.Define('PtSum','Sum(goodJet_pt30)')
 print a.DataFrame.GetColumnType('PtSum')
 h = a.DataFrame.Histo1D('PtSum')
 h.Draw('hist e')
 #---------------------
 print ('%s secs'%(time.time() - start))
+input('')

--- a/benchmark/ex8.py
+++ b/benchmark/ex8.py
@@ -20,6 +20,5 @@ a.Define('MT','NonZlep_idx == -1 ? -1 : analyzer::transverseMass(MET_pt, Lepton_
 a.Cut('MT_cut','MT>=0')
 h = a.DataFrame.Histo1D('MT')
 h.Draw('hist e')
-a.PrintNodeTree('test_tree',True,True)
 #---------------------
 print ('%s secs'%(time.time() - start))

--- a/benchmark/ex8.py
+++ b/benchmark/ex8.py
@@ -11,7 +11,7 @@ from TIMBER.Analyzer import analyzer
 from TIMBER.Tools.Common import CompileCpp
 CompileCpp('benchmark/ex.cc')
 
-a = analyzer('examples/ttbar16_sample.root')
+a = analyzer('examples/ttbar16_sample.root') # GluGlu sample is incomplete and missing electrons - this is a private stand in that must be replaced to work
 a.MergeCollections("Lepton",["Electron","Muon"])
 a.Cut('nLepton2','nLepton>2')
 a.Define('Lepton_vect','analyzer::TLvector(Lepton_pt, Lepton_eta, Lepton_phi, Lepton_mass)')

--- a/benchmark/ex8.py
+++ b/benchmark/ex8.py
@@ -1,0 +1,24 @@
+'''Plot the transverse mass of the Missing ET and a lepton for events with at least
+3 leptons and two of the leptons make up a Z (same flavor, opp sign, closest to invar
+mass of 91.2 GeV), where the lepton being plotted is the third lepton.'''
+# Lucas' Note: There could be four leptons in the event where two satisfy the Z condition
+# and then either of the remaining two could be the one used in the transverse mass
+# calculation. I do not consider that case (the first that comes up will be picked here).
+import time
+start = time.time()
+#---------------------
+from TIMBER.Analyzer import analyzer
+from TIMBER.Tools.Common import CompileCpp
+CompileCpp('benchmark/ex.cc')
+
+a = analyzer('examples/ttbar16_sample.root')
+a.MergeCollections("Lepton",["Electron","Muon"])
+a.Cut('nLepton2','nLepton>2')
+a.Define('Lepton_vect','analyzer::TLvector(Lepton_pt, Lepton_eta, Lepton_phi, Lepton_mass)')
+a.Define('NonZlep_idx','NonZlep(Lepton_vect,Lepton_pdgId,Lepton_charge)')
+a.Define('MT','NonZlep_idx == -1 ? -1 : analyzer::transverseMass(MET_pt, Lepton_pt[NonZlep_idx], MET_phi, Lepton_phi[NonZlep_idx])')
+a.Cut('MT_cut','MT>=0')
+h = a.DataFrame.Histo1D('MT')
+h.Draw('hist e')
+#---------------------
+print ('%s secs'%(time.time() - start))

--- a/benchmark/ex8.py
+++ b/benchmark/ex8.py
@@ -20,5 +20,6 @@ a.Define('MT','NonZlep_idx == -1 ? -1 : analyzer::transverseMass(MET_pt, Lepton_
 a.Cut('MT_cut','MT>=0')
 h = a.DataFrame.Histo1D('MT')
 h.Draw('hist e')
+a.PrintNodeTree('test_tree',True,True)
 #---------------------
 print ('%s secs'%(time.time() - start))

--- a/benchmark/ex9.py
+++ b/benchmark/ex9.py
@@ -15,7 +15,7 @@ binning_tuples = {
     'nJet': ('nJet','Number of Jets',10,0,10)
 }
 
-a = analyzer('examples/ttbar16_sample.root')
+a = analyzer('examples/GluGluToHToTauTau_full.root')
 raw_hists = a.MakeHistsWithBinning(binning_tuples)
 a.Cut('MET_cut','MET_pt>20')
 METcut_hists = a.MakeHistsWithBinning(binning_tuples)

--- a/benchmark/ex9.py
+++ b/benchmark/ex9.py
@@ -1,0 +1,33 @@
+'''Create a group of plots (jet pT, eta, phi, N_jets). Now make
+it for all events, for events with missing et > 20 GeV, and for
+events with missing et > 20 GeV and 2 jets with 40 GeV and abs(eta)
+< 1.0. Demonstrate making "groups" of plots, and a graphical cut flow'''
+import time
+start = time.time()
+#---------------------
+import ROOT
+from TIMBER.Analyzer import analyzer
+
+binning_tuples = {
+    'Jet_pt': ('Jet_pt','Jet p_{T}',100,0,500),
+    'Jet_eta': ('Jet_eta','Jet #eta',100,-5,5),
+    'Jet_phi': ('Jet_phi','Jet #phi',100,-3.14,3.14),
+    'nJet': ('nJet','Number of Jets',10,0,10)
+}
+
+a = analyzer('examples/ttbar16_sample.root')
+raw_hists = a.MakeHistsWithBinning(binning_tuples)
+a.Cut('MET_cut','MET_pt>20')
+METcut_hists = a.MakeHistsWithBinning(binning_tuples)
+a.Cut('Jet_PtEta_cut','Sum(Jet_pt>40 && abs(Jet_eta)<1.0) > 1')
+final_hists = a.MakeHistsWithBinning(binning_tuples)
+
+all_hists = raw_hists+METcut_hists+final_hists
+
+out_file = ROOT.TFile.Open('benchmark/ex9_hists.root','RECREATE')
+all_hists.Do('Write')
+out_file.Close()
+
+a.PrintNodeTree('benchmark/ex9_tree.pdf')
+#---------------------
+print ('%s secs'%(time.time() - start))

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setuptools.setup(
     include_package_data=True,
     # cmdclass={'install': AddToPath},
     install_requires = [
+        "graphviz==0.14.2",
         "pygraphviz==1.5",
         "networkx==2.2",
         "clang==6.0.0.2"

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setuptools.setup(
     include_package_data=True,
     # cmdclass={'install': AddToPath},
     install_requires = [
-        "pygraphviz",
+        "pygraphviz==1.5",
         "networkx==2.2",
         "clang==6.0.0.2"
     ]

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
     # cmdclass={'install': AddToPath},
     install_requires = [
         "pygraphviz",
-        "networkx",
+        "networkx==2.2",
         "clang==6.0.0.2"
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,8 @@ setuptools.setup(
     include_package_data=True,
     # cmdclass={'install': AddToPath},
     install_requires = [
-        "graphviz",
+        "pygraphviz",
+        "networkx",
         "clang==6.0.0.2"
     ]
 )

--- a/setup.sh
+++ b/setup.sh
@@ -5,6 +5,12 @@ then
   return
 fi
 
+if ! command -v dot &> /dev/null
+then
+  echo "dot (graphviz) could not be found. Please install it first... (on Ubuntu `sudo apt-get install graphviz`)"
+  exit
+fi
+
 python setup.py install
 activate_path=$VIRTUAL_ENV/bin/activate
 TIMBERPATH="$PWD/"

--- a/setup.sh
+++ b/setup.sh
@@ -7,7 +7,7 @@ fi
 
 if ! command -v dot &> /dev/null
 then
-  echo "dot (graphviz) could not be found. Please install it first... (on Ubuntu `sudo apt-get install graphviz`)"
+  echo "dot (graphviz) could not be found. Please install it first... (on Ubuntu `sudo apt-get install graphviz libgraphviz-dev`)"
   exit
 fi
 

--- a/test/test.json
+++ b/test/test.json
@@ -1,0 +1,8 @@
+{
+    "test1": 1,
+    "test2": {
+        "float": 1.0,
+        "str": "string",
+        "list": []
+    }
+}

--- a/test/test_Analyzer.py
+++ b/test/test_Analyzer.py
@@ -24,7 +24,7 @@ class TestAnalyzer():
 
     def test_GetTrackedNodeNames(self):
         '''Test GetTrackNodeNames method after adding a node'''
-        assert self.a.GetTrackedNodeNames() == ['test_cut1','lead_vector','sublead_vector','invariantMass']
+        assert self.a.GetTrackedNodeNames() == ['base','test_cut1','lead_vector','sublead_vector','invariantMass']
 
     def test_makehist(self):
         '''Makes a simple histogram of the defined variable'''

--- a/test/test_Analyzer.py
+++ b/test/test_Analyzer.py
@@ -1,6 +1,6 @@
-import ROOT
+import ROOT, os
 ROOT.gROOT.SetBatch(True)
-from TIMBER.Analyzer import analyzer, CutGroup, VarGroup
+from TIMBER.Analyzer import *
 from TIMBER.Tools.Common import CompileCpp
 
 class TestAnalyzer():
@@ -8,6 +8,7 @@ class TestAnalyzer():
     def setup_class(cls):
         CompileCpp('TIMBER/Framework/include/common.h') # Compile (via gInterpreter) commonly used c++ code
         CompileCpp('examples/example.cc')
+        # CompileCpp('test/test_weight.cc')
         cls.a = analyzer('examples/GluGluToHToTauTau.root')
         cls.a.Cut("test_cut1", "Jet_pt.size() > 0")
         cls.a.Define('lead_vector', 'analyzer::TLvector(Jet_pt[0],Jet_eta[0],Jet_phi[0],Jet_mass[0])')
@@ -38,22 +39,47 @@ class TestAnalyzer():
         self.a.GetActiveNode().Snapshot(out_vars,str(tmp_path)+'/ex1_out.root','test_snapshot',lazy=False,openOption='RECREATE') 
         assert True
 
-    def test_AddCorrection(self):
+    def test_Correction(self):
+        c = Correction('testWeight','test/test_weight.cc')
+        self.a.Define('Jet_pt0','Jet_pt[0]')
+        self.a.AddCorrection(c,['Jet_pt0'])
+        self.a.MakeWeightCols()
+        htemplate = ROOT.TH1F('th1','',100,0,1000)
+        hgroup = self.a.MakeTemplateHistos(htemplate,'Jet_pt0')
+        print ([hgroup[h].GetName() for h in hgroup.keys()])
+        self.a.DrawTemplates(hgroup, './')
         pass
 
-    def test_MakeWeightCols(self):
+    def test_CommonVars(self):
+        assert self.a.CommonVars(["Muon","Tau"]) == ['phi', 'pt', 'charge', 'eta', 'mass', 'genPartIdx', 'jetIdx']
         pass
 
-    def test_MakeTemplateHistos(self):
+    def test_MergeCollections(self):
+        self.a.MergeCollections('Lepton',["Muon","Tau"])
         pass
 
-    def test_DrawTemplates(self):
+    def test_SubCollection(self):
+        self.a.SubCollection('Jet30','Jet','Jet_pt>30')
         pass
 
     def test_Nminus1(self):
+        cgroup = CutGroup('Nminus1Test')
+        cgroup.Add('cut1','Jet_eta[0] < 2.4 && Jet_eta[1] < 2.4')
+        cgroup.Add('cut2','All(Muon_pt < 30)')
+        cgroup.Add('cut3','Sum(Jet_btag > 0.5) > 1')
+        self.a.Nminus1(cgroup)
         pass
 
     def test_PrintNodeTree(self):
+        self.a.PrintNodeTree('test.pdf')
+        pass
+
+    def test_GetTriggerString(self):
+        assert self.a.GetTriggerString(['HLT_IsoMu24','HLT_IsoMu24_eta2p1','NotReal']) == '((HLT_IsoMu24==1) || (HLT_IsoMu24_eta2p1==1))'
+        pass
+
+    def test_GetFlagString(self):
+        assert self.a.GetFlagString(['HLT_IsoMu24','HLT_IsoMu24_eta2p1','NotReal']) == '((HLT_IsoMu24==1) && (HLT_IsoMu24_eta2p1==1))'
         pass
 
 def test_Groups():

--- a/test/test_Analyzer.py
+++ b/test/test_Analyzer.py
@@ -51,7 +51,7 @@ class TestAnalyzer():
         pass
 
     def test_CommonVars(self):
-        assert self.a.CommonVars(["Muon","Tau"]) == ['phi', 'pt', 'charge', 'eta', 'mass', 'genPartIdx', 'jetIdx']
+        assert sorted(self.a.CommonVars(["Muon","Tau"])) == sorted(['phi', 'pt', 'charge', 'eta', 'mass', 'genPartIdx', 'jetIdx'])
         pass
 
     def test_MergeCollections(self):

--- a/test/test_Common.py
+++ b/test/test_Common.py
@@ -1,5 +1,5 @@
 from TIMBER.Analyzer import analyzer
-from TIMBER.Tools.Common import CompileCpp
+from TIMBER.Tools.Common import *
 
 class CommonTest():
     @classmethod
@@ -12,11 +12,28 @@ class CommonTest():
     def test_CutflowTxt(self):
         pass
 
-    def test_openJSON(self):
+    def test_OpenJSON(self):
+        assert OpenJSON('test.json') == {
+            "test1": 1,
+            "test2": {
+                "float": 1.0,
+                "str": "string",
+                "list": []
+            }
+        }
         pass
 
     def test_GetHistBinningTuple(self):
-        pass
-
-    def test_StitchQCD(self):
+        h = ROOT.TH1F('testH','',10,0,10)
+        binning,dim = GetHistBinningTuple(h)
+        assert binning == (10,0,10)
+        assert dim == 1
+        h2 = ROOT.TH2F('testH2','',10,0,10,20,0,20)
+        binning,dim = GetHistBinningTuple(h2)
+        assert binning == (10,0,10,20,0,20)
+        assert dim == 2
+        h3 = ROOT.TH2F('testH2','',10,0,10,20,0,20,30,0,30)
+        binning,dim = GetHistBinningTuple(h3)
+        assert binning == (10,0,10,20,0,20,30,0,30)
+        assert dim == 3
         pass

--- a/test/test_weight.cc
+++ b/test/test_weight.cc
@@ -1,0 +1,35 @@
+#include <vector>
+#include "ROOT/RVec.hxx"
+
+using namespace ROOT::VecOps;
+
+class testWeight
+{
+private:
+    std::vector<float> boundaries, weights, up_err, down_err;
+public:
+    testWeight();
+    RVec<float> eval(float pt);
+};
+
+testWeight::testWeight() {
+    boundaries = {0.,100.,120.,150.,200.,10000.};
+    weights = {0.95, 0.98, 1.05, 1.01, 1.10, 1};
+    up_err = {0.02, 0.02, 0.02, 0.02, 0.02, 0.02};
+    down_err = {0.02, 0.02, 0.02, 0.02, 0.02, 0.02};
+}
+
+RVec<float> testWeight::eval(float pt) {
+    RVec<float> out;
+    for (size_t i = 0; i < weights.size(); i++) {
+        if ((pt > boundaries[i]) && (pt < boundaries[i+1])) {
+            out.push_back(weights[i]);
+            out.push_back(weights[i]+up_err[i]);
+            out.push_back(weights[i]-down_err[i]);
+            return out;
+        }
+    }
+    out = {1.,1.,1.};
+    return out;
+}
+


### PR DESCRIPTION
Benchmark examples written but general code development was looped in as well. Most of the general development was to benefit the benchmarks - they served as case studies to fill out some of the tooling. Some of the development was done to make debugging easier or for the sake of future ideas to implement.

## Setup/install
- Drop `graphviz` dependency
- Add `pygraphviz` and `networkx` dependencies
- Add `apt-get` command in GitHub Action

## Benchmarks
- Benchmarks 1-9 added in `benchmarks/ex*.py`. Some internal comments included about what was done. The CMS Open Data sample included in the examples/ folder does not have electrons so it was not used for benchmarks 7 or 8 (these need the tester to use their own private file which this repo does not provide).
- Filled out more of the general testing with pytest.

## New to `analyzer`
- `Close()`: Implemented to safely delete an analyzer instance.
- `__str__`: Implemented to provide an informational printout when `print(<analyzer>)` is called.
- Can specify Node type as `Cut` and `Define` argument if you have a specific type you'd like to track.
- `SubCollection()`: Creates a named sub-collection based on some discriminant where the sub-collection has all of the same branches as the parent but only includes vector entries that passed the discriminant.
NOTE: `myColl_var1` is an `RVec` and so `myColl_var1 > 5` returns a vector the same size as `myColl_var1` but filled with bools for each entry. These bools determine which entries of the `RVec`s of the sub-collection branches are made.
```python
a = analyzer(...)
# Say there is a collection "myColl" with branches "myColl_var1", "myColl_var2", "myColl_var3"
a.SubCollection("mySubColl","myColl","myColl_var1 > 5")
# Now there is a new collection "mySubColl" with branches "mySubColl_var1", "mySubColl_var2", "mySubColl_var3"
# which only have values where myColl_var1 > 5
```
- `MergeCollections()`: Creates a new collection which is a merge of all provided collections. New collection has variables that are common between collections being merged.
- `CommonVars()`: Finds the common variables between a set of collections (provided as a list of names).
- `PrintNodeTree()`: Added optional argument `toSkip=[]` which skips plotting any nodes of types specified by `toSkip`. Note that the function checks for the type in `toSkip` as a substring of the type of the Node. So if you provide `toSkip=["Define"]` all nodes of type "MergeDefine" and "SubCollDefine" will also be dropped.
    - Also switched to using `networkx` (which uses `pygraphviz`).
- `MakeHistsWithBinning()`: Batch creates histograms at the current `ActiveNode` based on the input `histDict` which is formatted as `{[<column name>]: <binning tuple>}`. The dimensions of the returned histograms are determined from the size of `[<column name>]`.
    - `[<column name>]` is a list of column names that you'd like to plot against each other in [x,y,z] order
    - `binning_tuple` is  the set of arguments that would normally be passed to `TH1`. 

## New to `Node`
- Add "types" to Nodes to denote what was done to produce the Node. Currently used for controlling nodes present in `PrintNodeTree()` output. Current possible types are "Define", "Cut", "MergeDefine", "SubCollDefine", "Correction".
- `Close()`: Implemented to safely delete a Node instance.
- `__str__`: Implemented to provide an informational printout when `print(<node>)` is called.

## New to `HistGroup`
- `Merge()`: Adds together all of the histograms in the group and returns the output histogram.

## New to C++ Code
### `common.h`
- `transverseMass()` to get transverse mass of MET + one object. Could be more generalized.
- 2nd constructor for `TLvector()` that takes `RVec`s as arguments rather than floats (returns back an `RVec` of `PtEtaPhiMVector`s)

## Small bug fixes
- Fix `Common.py` TIMBER imports
- Make `fileName` attribute public (used for new `__str__` method for printing `analyzer` object)
- Add `BaseNode` to `AllNodes` for tracking
- Force `BaseNode` to zero children on initialization to avoid memory issues
- Fix `Group` addition
