### PR TITLE
fix to read files from /afs

### DIFF
--- a/TIMBER/Analyzer.py
+++ b/TIMBER/Analyzer.py
@@ -96,7 +96,7 @@ class analyzer(object):
             txt_file = open(self.fileName,"r")
             for l in txt_file.readlines():
                 thisfile = l.strip()
-                if 'root://' not in thisfile and '/store/' in thisfile: thisfile='root://cms-xrd-global.cern.ch/'+thisfile
+                if 'root://' not in thisfile and thisfile.startswith('/store/'): thisfile='root://cms-xrd-global.cern.ch/'+thisfile
                 self.__eventsChain.Add(thisfile)
                 RunChain.Add(thisfile)
         else: 


### PR DESCRIPTION
Fix so that TIMBER can open .txt files with paths starting with  `/afs/cern.ch/user/m/username/store/`