### PR TITLE
Add top and W tagging SF modules

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -31,6 +31,9 @@ jobs:
     - name: Setup environment
       run: |
         sudo apt-get install graphviz libgraphviz-dev libboost-all-dev
+        echo "\n---------\nDEBUG\n---------\n"
+        ls /usr/lib/x86_64-linux-gnu/ | grep 'libclang'
+        echo "\n-----------------\n"
         sudo ln -s /usr/lib/x86_64-linux-gnu/libclang-6.0.so.1 /usr/lib/x86_64-linux-gnu/libclang.so
         python -m pip install --upgrade pip==20.3
         pip install virtualenv

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -34,7 +34,7 @@ jobs:
         echo "\n---------\nDEBUG\n---------\n"
         ls /usr/lib/x86_64-linux-gnu/ | grep 'libclang'
         echo "\n-----------------\n"
-        sudo ln -s /usr/lib/x86_64-linux-gnu/libclang-6.0.so.1 /usr/lib/x86_64-linux-gnu/libclang.so
+        sudo ln -s /usr/lib/x86_64-linux-gnu/libclang-9.so.1 /usr/lib/x86_64-linux-gnu/libclang.so
         python -m pip install --upgrade pip==20.3
         pip install virtualenv
         python -m virtualenv timber-env

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -31,9 +31,9 @@ jobs:
     - name: Setup environment
       run: |
         sudo apt-get install graphviz libgraphviz-dev libboost-all-dev
-        echo "\n---------\nDEBUG\n---------\n"
+        echo "---------DEBUG---------"
         ls /usr/lib/x86_64-linux-gnu/ | grep 'libclang'
-        echo "\n-----------------\n"
+        echo "-------END DEBUG-------"
         sudo ln -s /usr/lib/x86_64-linux-gnu/libclang-9.so.1 /usr/lib/x86_64-linux-gnu/libclang.so
         python -m pip install --upgrade pip==20.3
         pip install virtualenv

--- a/TIMBER/Analyzer.py
+++ b/TIMBER/Analyzer.py
@@ -1930,6 +1930,12 @@ class ModuleWorker(object):
             try:
                 if a == "":
                     line += '"", '
+                elif a == "true" or a == "false":
+                    line += '%s, '%(a)
+                elif isinstance(a,bool) and a == True:
+                    line += 'true, '
+                elif isinstance(a,bool) and a == False:
+                    line += 'false, '
                 elif a[0].isalpha():
                     line += '"%s", '%(a)
                 else:

--- a/TIMBER/Analyzer.py
+++ b/TIMBER/Analyzer.py
@@ -1905,7 +1905,14 @@ class ModuleWorker(object):
                                         default_val = ''.join([tok.spelling for tok in list(translation_unit.get_tokens(extent=list(arg.walk_preorder())[-1].extent))])
                                         funcs[methodname][arg.spelling] = default_val
                                     else:
-                                        funcs[methodname][arg.spelling] = None                                  
+                                        funcs[methodname][arg.spelling] = None  
+
+        if len(list(funcs.keys())) == 0:
+            if ('TIMBER/Framework/src' in self._script):
+                self._script = self._script.replace('src','include').replace('.cc','.h')
+                funcs = self._getFuncInfo(funcname)
+            else:
+                raise ValueError('Could not find `%s` in file %s'%(funcname,self._script))
 
         return funcs
 

--- a/TIMBER/Framework/include/TopTag_SF.h
+++ b/TIMBER/Framework/include/TopTag_SF.h
@@ -1,0 +1,62 @@
+#ifndef _TIMBER_TOPTAG_SF
+#define _TIMBER_TOPTAG_SF
+#include <string>
+#include <TFile.h>
+#include <TH1.h>
+#include <TString.h>
+#include <Math/Vector4Dfwd.h>
+#include <Math/GenVector/LorentzVector.h>
+#include <Math/GenVector/PtEtaPhiM4D.h>
+#include "GenMatching.h"
+using LVector = ROOT::Math::PtEtaPhiMVector;
+
+class TopTag_SF {
+    private:
+        std::string workpoint_name;
+        int _year;
+        std::map<int, std::map<std::string, TH1F*>> _hists;
+        TFile *_file;
+
+    public:
+        TopTag_SF(int year, int workpoint, bool NoMassCut=false);
+        ~TopTag_SF(){};
+        int NMerged(LVector top_vect, RVec<Particle*> Ws,
+                RVec<Particle*> quarks, GenParticleTree GPT);
+
+        template <class T>
+        RVec<double> eval(LVector top_vect, std::vector<T> GenParts){
+            GenParticleTree GPT(GenParts.size());
+            // prongs are final particles we'll check
+            RVec<Particle*> Ws, quarks; 
+            int this_pdgId;
+
+            for (size_t i = 0; i < GenParts.size(); i++) {
+                Particle* this_particle = GPT.AddParticle(Particle(i,GenParts[i])); // add particle to tree
+                this_pdgId = this_particle->pdgId;
+                if (abs(this_pdgId) == 24) {
+                    Ws.push_back(this_particle);
+                } else if (abs(this_pdgId) >= 1 && abs(this_pdgId) <= 5) {
+                    quarks.push_back(this_particle);
+                }
+            }
+            int nMergedProngs = NMerged(top_vect, Ws, quarks, GPT);
+            std::vector<double> sfs(3);
+            if (nMergedProngs > 0){
+                if (top_vect.Pt() > 5000) {
+                    sfs = {_hists[nMergedProngs]["nom"]->GetBinContent(_hists[nMergedProngs]["nom"]->GetNbinsX()),
+                           _hists[nMergedProngs]["up"]->GetBinContent(_hists[nMergedProngs]["up"]->GetNbinsX()),
+                           _hists[nMergedProngs]["down"]->GetBinContent(_hists[nMergedProngs]["down"]->GetNbinsX())
+                            };
+                } else {                    
+                    sfs = {_hists[nMergedProngs]["nom"]->GetBinContent(_hists[nMergedProngs]["nom"]->FindFixBin(top_vect.Pt())),
+                           _hists[nMergedProngs]["up"]->GetBinContent(_hists[nMergedProngs]["up"]->FindFixBin(top_vect.Pt())),
+                           _hists[nMergedProngs]["down"]->GetBinContent(_hists[nMergedProngs]["down"]->FindFixBin(top_vect.Pt()))
+                            };
+                }        
+            } else {
+                sfs = {1, 1, 1};
+            }
+            return sfs;
+        }
+};
+#endif

--- a/TIMBER/Framework/include/Wtag_SF.h
+++ b/TIMBER/Framework/include/Wtag_SF.h
@@ -1,3 +1,5 @@
+#ifndef _TIMBER_WTAG_SF
+#define _TIMBER_WTAG_SF
 #include <ROOT/RVec.hxx>
 
 class Wtag_SF {
@@ -25,3 +27,4 @@ class Wtag_SF {
          */
         ROOT::VecOps::RVec<float> eval(float tau21);
 };
+#endif

--- a/TIMBER/Framework/include/Wtag_SF.h
+++ b/TIMBER/Framework/include/Wtag_SF.h
@@ -1,0 +1,27 @@
+#include <ROOT/RVec.hxx>
+
+class Wtag_SF {
+    /**
+     * @brief C++ class to access scale factors associated with tau21+mass
+     * based W tagging. More details provided at [https://twiki.cern.ch/twiki/bin/view/CMS/JetWtagging](https://twiki.cern.ch/twiki/bin/view/CMS/JetWtagging)
+     * 
+     */
+    private:
+        int _year;
+        float _HP, _HPunc, _LP, _LPunc;
+    public:
+        /**
+         * @brief Construct a new Wtag_SF object
+         * 
+         * @param year 2016, 2017, 2018
+         */
+        Wtag_SF(int year);
+        ~Wtag_SF(){};
+        /**
+         * @brief Get the scale factor for a given tau21 value.
+         * 
+         * @param tau21 
+         * @return std::vector<float> Absolute (not relative) {nominal, up, down}
+         */
+        ROOT::VecOps::RVec<float> eval(float tau21);
+};

--- a/TIMBER/Framework/include/common.h
+++ b/TIMBER/Framework/include/common.h
@@ -253,12 +253,12 @@ namespace Pythonic {
      * @return bool True or false based on whether object is found in list.
      */
     template<typename T>
-    bool InList(T obj, std::vector<T> list) {
-        bool out;
+    int InList(T obj, std::vector<T> list) {
+        int out;
         auto pos = std::find(std::begin(list), std::end(list), obj);
         if (pos != std::end(list)){
-            out = true;
-        } else {out = false;}
+            out = pos - std::begin(list);
+        } else {out = -1;}
         return out;
     }
 

--- a/TIMBER/Framework/src/GenMatching.cc
+++ b/TIMBER/Framework/src/GenMatching.cc
@@ -6,14 +6,13 @@ bool GenMatching::BitChecker(const int &bit, int &number){
     if (result > 0) {return true;}
     else {return false;}
 }
-
-std::map <int, std::string> GenMatching::PDGIds {
-    {1,"d"}, {2,"u"}, {3,"s"}, {4,"c"}, {5,"b"}, {6,"t"},
-    {11,"e"}, {12,"nu_e"}, {13,"mu"}, {14,"nu_mu"},{ 15,"tau"},
-    {16,"nu_tau"}, {21,"g"}, {22,"photon"}, {23,"Z"}, {24,"W"}, {25,"h"}
-};
-
-std::map <std::string, int> GenMatching::GenParticleStatusFlags {
+namespace GenMatching {
+    std::map <int, std::string> PDGIds {
+        {1,"d"}, {2,"u"}, {3,"s"}, {4,"c"}, {5,"b"}, {6,"t"},
+        {11,"e"}, {12,"nu_e"}, {13,"mu"}, {14,"nu_mu"},{ 15,"tau"},
+        {16,"nu_tau"}, {21,"g"}, {22,"photon"}, {23,"Z"}, {24,"W"}, {25,"h"}
+    };
+    std::map <std::string, int> GenParticleStatusFlags {
         {"isPrompt", 0},
         {"isDecayedLeptonHadron", 1},
         {"isTauDecayProduct", 2},
@@ -29,82 +28,98 @@ std::map <std::string, int> GenMatching::GenParticleStatusFlags {
         {"isFirstCopy", 12},
         {"isLastCopy", 13},
         {"isLastCopyBeforeFSR", 14}
+    };
+}
+
+Particle::Particle(): parentIndex(-1){
+    childIndex.reserve(5);
 };
-
-Particle::Particle(){};
-
 void Particle::AddParent(int idx){
     parentIndex = idx;
 }
-
 void Particle::AddChild(int idx){
     childIndex.push_back(idx);
 }
-
+int Particle::GetParent(){
+    return parentIndex;
+}
+std::vector<int> Particle::GetChild(){
+    return childIndex;
+}
 float Particle::DeltaR(LVector input_vector){
     return ROOT::Math::VectorUtil::DeltaR(vect,input_vector);
-};
-
-std::vector<int> GenParticleTree::StoredIndexes(){
-    std::vector<int> current_idxs {};
-    for (size_t i = 0; i < nodes.size(); i++) {
-        current_idxs.push_back(nodes.at(i)->index);
+}
+void Particle::SetStatusFlags(int flags){
+    for (auto it = GenMatching::GenParticleStatusFlags.begin(); it != GenMatching::GenParticleStatusFlags.end(); ++it) {
+        statusFlags[it->first] = GenMatching::BitChecker(it->second, flags);
     }
-    return current_idxs;
+}
+int Particle::GetStatusFlag(std::string flagName){
+    return statusFlags[flagName];
+}
+std::map< std::string, bool> Particle::CompareToVector(LVector vect) {
+    std::map< std::string, bool> out;
+    out["sameHemisphere"] = (ROOT::Math::VectorUtil::DeltaPhi(this->vect,vect) < M_PI/2.0);
+    out["deltaR"] = (this->DeltaR(vect) < 0.8);
+    out["deltaM"] = (std::abs(vect.M() - this->vect.M())/this->vect.M() < 0.05);
+    return out;
 }
 
-void GenParticleTree::AddParticle(Particle* particle) {
-    Particle* staged_node = particle;
+GenParticleTree::GenParticleTree(int nParticles){
+    _noneParticle.flag = false;
+    _nodes.reserve(nParticles);
+};
 
+Particle* GenParticleTree::AddParticle(Particle particle) {
+    int new_particle_index = _nodes.size();
     // First check if current heads don't have new parents and 
     // remove them from heads if they do
     std::vector<int> heads_to_delete {};
-    for (size_t i = 0; i < heads.size(); i++) {
-        if (heads.at(i)->parentIndex == staged_node->index) {
+    for (size_t i = 0; i < _heads.size(); i++) {
+        if (_heads[i]->genPartIdxMother == particle.index) {
             heads_to_delete.push_back(i);
         }
     }
     // Need to delete indices in reverse order so as not to shift 
     // indices after a deletion
-    for (int ih = heads_to_delete.size(); ih >= 0; ih--) {
-        heads.erase(heads.begin()+ih);
+    for (int ih = heads_to_delete.size()-1; ih >= 0; ih--) {
+        _heads.erase(_heads.begin()+heads_to_delete[ih]);
     }
-   
-    // Next identify staged node has no parent (heads)
-    // If no parent, no other infor we can get from this particle
-    std::vector<int> indexes = StoredIndexes();
-    if (Pythonic::InList(staged_node->parentIndex, indexes)) {
-        heads.push_back(staged_node);
-        nodes.push_back(staged_node);
-    } else {
-        for (size_t inode = 0; inode < nodes.size(); inode++) {
-            if (staged_node->parentIndex == nodes[inode]->index){
-                staged_node->AddParent(inode);
-                nodes.at(inode)->AddChild(nodes.size());
-                nodes.push_back(staged_node);
-            }
-        }        
+    // Set relationship to all current nodes
+    for (int inode = 0; inode < _nodes.size(); inode++) {
+        if (_nodes[inode].genPartIdxMother == particle.index) {
+            _nodes[inode].AddParent(new_particle_index);
+            particle.AddChild(inode);
+        } else if (particle.genPartIdxMother == _nodes[inode].index) {
+            _nodes[inode].AddChild(new_particle_index);
+            particle.AddParent(inode);
+        }
     }
-};
+
+    _nodes.push_back(particle);
+    if (particle.GetParent() == -1) {
+        _heads.push_back(&_nodes.back());
+    }
+    return &_nodes.back();
+}
 
 std::vector<Particle*> GenParticleTree::GetChildren(Particle* particle){
-    std::vector<Particle*> children {};
-    for (size_t i = 0; i < particle->childIndex.size(); i++) {
-        children.push_back(nodes[particle->childIndex.at(i)]);
+    std::vector<Particle*> out;
+    int childIdx;
+    for (int i = 0; i < particle->childIndex.size(); i++) {
+        childIdx = particle->childIndex[i];
+        out.push_back(&_nodes[childIdx]);
     }
-    return children;
+    return out;
 }
-
 Particle* GenParticleTree::GetParent(Particle* particle) {
-    if (nodes.size() > particle->parentIndex){
-        return nodes.at(particle->parentIndex);
+    if (_nodes.size() > particle->GetParent()){
+        return &_nodes[particle->GetParent()];
     } else {
-        return &NoneParticle;
-    }
-    
+        return &_noneParticle;
+    }   
 }
-
-bool GenParticleTree::MatchParticleToString(Particle* particle, std::string string){
+bool GenParticleTree::_matchParticleToString(Particle* particle, std::string string){
     std::vector<int> pdgIds {}; 
     if (Pythonic::InString(":",string)) {
         int startId = std::stoi( string.substr(0,string.find(':')) );
@@ -119,19 +134,18 @@ bool GenParticleTree::MatchParticleToString(Particle* particle, std::string stri
 
     bool out;
     if (pdgIds.size() == 0) {
-        if (std::abs(*particle->pdgId) == std::stoi(string)) {
+        if (std::abs(particle->pdgId) == std::stoi(string)) {
             out = true;
         } else {out = false;}
     } else {
-        if (Pythonic::InList((int)std::abs(*particle->pdgId), pdgIds)) {
+        if (Pythonic::InList((int)std::abs(particle->pdgId), pdgIds)) {
             out = true;
         } else {out = false;}
     }
 
     return out;
 }
-
-std::vector<Particle*> GenParticleTree::RunChain(Particle* node, std::vector<std::string> chain) {
+std::vector<Particle*> GenParticleTree::_runChain(Particle* node, std::vector<std::string> chain) {
     std::vector<Particle*> nodechain {node};
     Particle* parent = GetParent(node);
     std::vector<std::string> chain_minus_first = {chain.begin()+1,chain.end()};
@@ -139,18 +153,17 @@ std::vector<Particle*> GenParticleTree::RunChain(Particle* node, std::vector<std
     if (chain.size() == 0) {
         return nodechain;
     } else if (parent->flag == false) {
-        nodechain.push_back(&NoneParticle);
-    } else if (MatchParticleToString(parent, chain.at(0))) {
-        Pythonic::Extend(nodechain, RunChain(parent,chain_minus_first));
+        nodechain.push_back(&_noneParticle);
+    } else if (_matchParticleToString(parent, chain.at(0))) {
+        Pythonic::Extend(nodechain, _runChain(parent,chain_minus_first));
     } else if (parent->pdgId == node->pdgId) {
-        Pythonic::Extend(nodechain, RunChain(parent, chain));
+        Pythonic::Extend(nodechain, _runChain(parent, chain));
     } else {
-        nodechain.push_back(&NoneParticle);
+        nodechain.push_back(&_noneParticle);
     }
 
     return nodechain;
 }
-
 std::vector<std::vector<Particle*>> GenParticleTree::FindChain(std::string chainstring) {
     std::vector<std::string> reveresed_chain = Pythonic::Split(chainstring,'>');
     std::reverse(reveresed_chain.begin(), reveresed_chain.end());
@@ -160,10 +173,10 @@ std::vector<std::vector<Particle*>> GenParticleTree::FindChain(std::string chain
     std::vector<Particle*> chain_result;
     std::vector<std::vector<Particle*>> out;
 
-    for (size_t inode = 0; inode < nodes.size(); inode++) {
-        Particle* n = nodes[inode];
-        if (MatchParticleToString(n, reveresed_chain.at(0))) {
-            chain_result = RunChain(n,reveresed_chain_minus_first);
+    for (size_t inode = 0; inode < _nodes.size(); inode++) {
+        Particle* n = &_nodes[inode];
+        if (_matchParticleToString(n, reveresed_chain.at(0))) {
+            chain_result = _runChain(n,reveresed_chain_minus_first);
             bool no_NoneParticle = true;
             for (size_t icr = 0; icr < chain_result.size(); icr++) {
                 if (chain_result[icr]->flag == false) {
@@ -176,62 +189,3 @@ std::vector<std::vector<Particle*>> GenParticleTree::FindChain(std::string chain
     }
     return out;
 }
-
-GenParticleObjs::GenParticleObjs(RVec<float> in_pt, 
-                RVec<float> in_eta, RVec<float> in_phi, 
-                RVec<float> in_m, RVec<int> in_pdgId, 
-                RVec<int> in_status, RVec<int> in_statusFlags, 
-                RVec<int> in_genPartIdxMother) {
-
-    GenPartCollection.RVecInt = { 
-        {"pdgId",&in_pdgId},
-        {"status",&in_status},
-        {"statusFlags",&in_statusFlags},
-        {"genPartIdxMother",&in_genPartIdxMother}
-    };
-    GenPartCollection.RVecFloat = { 
-        {"pt",&in_pt},
-        {"eta",&in_eta},
-        {"phi",&in_phi},
-        {"m",&in_m}
-    };
-    // Settings for the "set" particle
-    particle.index = -1;
-}
-
-GenParticleObjs::GenParticleObjs(Collection genParts) {
-    GenPartCollection = genParts;
-};
-
-void GenParticleObjs::SetStatusFlags(int particleIndex){
-    for (auto it = GenMatching::GenParticleStatusFlags.begin(); it != GenMatching::GenParticleStatusFlags.end(); ++it) {
-        particle.statusFlags[it->first] = GenMatching::BitChecker(it->second, GenPartCollection.RVecInt["statusFlags"]->at(particleIndex));
-    }
-}
-
-std::map< std::string, bool> GenParticleObjs::CompareToVector(LVector vect) {
-    std::map< std::string, bool> out;
-    out["sameHemisphere"] = (ROOT::Math::VectorUtil::DeltaPhi(particle.vect,vect) < M_PI);
-    out["deltaR"] = (particle.DeltaR(vect) < 0.8);
-    out["deltaM"] = (std::abs(vect.M() - particle.vect.M())/particle.vect.M() < 0.05);
-    return out;
-};
-
-Particle GenParticleObjs::SetIndex(int idx) {
-    particle.index = idx;
-    particle.pdgId = &GenPartCollection.RVecInt["pdgId"]->at(idx);
-    SetStatusFlags(idx);
-    particle.parentIndex = GenPartCollection.RVecInt["genPartIdxMother"]->at(idx);
-    particle.vect.SetCoordinates(
-        GenPartCollection.RVecFloat["pt"]->at(idx),
-        GenPartCollection.RVecFloat["eta"]->at(idx),
-        GenPartCollection.RVecFloat["phi"]->at(idx),
-        GenPartCollection.RVecFloat["m"]->at(idx)
-        );
-
-    return particle;
-};   
-
-int GenParticleObjs::GetStatusFlag(std::string flagName){
-    return particle.statusFlags[flagName];
-};

--- a/TIMBER/Framework/src/JES_weight.cc
+++ b/TIMBER/Framework/src/JES_weight.cc
@@ -14,7 +14,7 @@ bool JES_weight::check_type_exists() {
     if (_uncertType == "") {
         out = true;
     } else {
-        if (Pythonic::InList(_uncertType,this->get_sources())) {
+        if (Pythonic::InList(_uncertType,this->get_sources())>-1) {
             out = true;
         } else {
             out = false;

--- a/TIMBER/Framework/src/TopTag_SF.cc
+++ b/TIMBER/Framework/src/TopTag_SF.cc
@@ -1,0 +1,78 @@
+#include "../include/TopTag_SF.h"
+
+TopTag_SF::TopTag_SF(int year, int workpoint, bool NoMassCut) :
+        _year(year > 2000 ? year - 2000 : year) {
+
+    workpoint_name = "wp"+std::to_string(workpoint);
+    std::string filename = "SFs/20"+std::to_string(_year)+"TopTaggingScaleFactors";
+    if (NoMassCut){filename += "_NoMassCut.root";}
+    else {filename += ".root";}
+    
+    _file = new TFile(filename.c_str(),"READ");
+
+    _hists[3]["nom"] = (TH1F*)_file->Get(TString("PUPPI_"+workpoint_name+"_btag/sf_mergedTop_nominal"));
+    _hists[3]["up"] = (TH1F*)_file->Get(TString("PUPPI_"+workpoint_name+"_btag/sf_mergedTop_up"));
+    _hists[3]["down"] = (TH1F*)_file->Get(TString("PUPPI_"+workpoint_name+"_btag/sf_mergedTop_down"));
+
+    _hists[2]["nom"] = (TH1F*)_file->Get(TString("PUPPI_"+workpoint_name+"_btag/sf_semimerged_nominal"));
+    _hists[2]["up"] = (TH1F*)_file->Get(TString("PUPPI_"+workpoint_name+"_btag/sf_semimerged_up"));
+    _hists[2]["down"] = (TH1F*)_file->Get(TString("PUPPI_"+workpoint_name+"_btag/sf_semimerged_down"));
+
+    _hists[1]["nom"] = (TH1F*)_file->Get(TString("PUPPI_"+workpoint_name+"_btag/sf_notmerged_nominal"));
+    _hists[1]["up"] = (TH1F*)_file->Get(TString("PUPPI_"+workpoint_name+"_btag/sf_notmerged_up"));
+    _hists[1]["down"] = (TH1F*)_file->Get(TString("PUPPI_"+workpoint_name+"_btag/sf_notmerged_down"));
+};
+
+int TopTag_SF::NMerged(LVector top_vect, RVec<Particle*> Ws, RVec<Particle*> quarks, GenParticleTree GPT) {
+    int nmerged = 0;
+    // prongs are final particles we'll check
+    RVec<Particle*> prongs; 
+
+    Particle *q, *bottom_parent;
+    for (size_t iq = 0; iq < quarks.size(); iq++) {
+        q = quarks[iq];
+        if (abs(q->pdgId) == 5) { // if bottom
+            bottom_parent = GPT.GetParent(q);
+            if (bottom_parent->flag != false) { // if has parent
+                // if parent is a matched top
+                if (abs(bottom_parent->pdgId) == 6 && bottom_parent->DeltaR(top_vect) < 0.8) { 
+                    prongs.push_back(q);
+                }
+            }
+        }
+    }
+
+    Particle *W, *this_W, *wChild, *wParent;
+    std::vector<Particle*> this_W_children;
+    for (size_t iW = 0; iW < Ws.size(); iW++) {
+        W = Ws[iW];
+        wParent = GPT.GetParent(W);
+        if (wParent->flag != false) {
+            // Make sure parent is top that's in the jet
+            if (abs(wParent->pdgId) == 6 && wParent->DeltaR(top_vect) < 0.8) {
+                this_W = W;
+                this_W_children = GPT.GetChildren(this_W);
+                // Make sure the child is not just another W
+                if ((this_W_children.size() == 1) && (this_W_children[0]->pdgId == W->pdgId)) {
+                    this_W = this_W_children[0];
+                    this_W_children = GPT.GetChildren(this_W);
+                }
+                // Add children as prongs
+                for (size_t ichild = 0; ichild < this_W_children.size(); ichild++) {
+                    wChild = this_W_children[ichild];
+                    int child_pdgId = wChild->pdgId;
+                    if (abs(child_pdgId) >= 1 && abs(child_pdgId) <= 5) {
+                        prongs.push_back(wChild);
+                    }
+                } 
+            }
+        }
+    }
+    for (size_t iprong = 0; iprong < prongs.size(); iprong++) {
+        if (prongs[iprong]->DeltaR(top_vect) < 0.8) {
+            nmerged++;
+        }
+    }
+    return std::min(nmerged,3);
+}
+

--- a/TIMBER/Framework/src/Wtag_SF.cc
+++ b/TIMBER/Framework/src/Wtag_SF.cc
@@ -1,0 +1,54 @@
+#include "../include/Wtag_SF.h"
+
+Wtag_SF::Wtag_SF(int year){
+    if (year > 2000) {
+        _year = year - 2000;
+    } else {
+        _year = year;
+    }
+
+    if (year == 16) {
+        _HP = 1.00; _HPunc = 0.06;
+        _LP = 0.96; _LPunc = 0.11;
+    } else if (year == 17) {
+        _HP = 0.97; _HPunc = 0.06;
+        _LP = 1.14; _LPunc = 0.29;
+    } else if (year == 18) {
+        _HP = 0.98; _HPunc = 0.027;
+        _LP = 1.12; _LPunc = 0.275;
+    } else {
+        throw "Wtag_SF: Year not supported";
+    }
+}
+
+ROOT::VecOps::RVec<float> Wtag_SF::eval(float tau21) {
+    ROOT::VecOps::RVec<float> out;
+
+    if (_year == 16) {
+        if (tau21 < 0.4) {
+            out = {_HP, _HP+_HPunc, _HP-_HPunc};
+        } else {
+            out = {_LP, _LP+_LPunc, _LP-_LPunc};
+        }
+
+    } else if (_year == 17) {
+        if (tau21 < 0.45) {
+            out = {_HP, _HP+_HPunc, _HP-_HPunc};
+        } else if (tau21 < 0.75) {
+            out = {_LP, _LP+_LPunc, _LP-_LPunc};
+        } else {
+            out = {1., 1., 1.};
+        }
+
+    } else if (_year == 18) {
+        if (tau21 < 0.4) {
+            out = {_HP, _HP+_HPunc, _HP-_HPunc};
+        } else if (tau21 < 0.75) {
+            out = {_LP, _LP+_LPunc, _LP-_LPunc};
+        } else {
+            out = {1., 1., 1.};
+        }
+    } 
+
+    return out;
+}

--- a/TIMBER/Utilities/CollectionGen.py
+++ b/TIMBER/Utilities/CollectionGen.py
@@ -25,7 +25,10 @@ def GetKeyValForBranch(rdf, bname, includeType=True):
     varname = '_'.join(bname.split('_')[1:])
     out = (collname, '')
 
-    if varname != '':
+    branch_names = [str(b) for b in rdf.GetColumnNames()]
+    if varname == '' or 'n'+collname not in branch_names:
+        pass
+    elif varname != '':
         collType = str(rdf.GetColumnType(bname)).replace('ROOT::VecOps::RVec<','')
         if collType.endswith('>'): collType = collType[:-1]
         collType += '&'

--- a/TIMBER/data/README.md
+++ b/TIMBER/data/README.md
@@ -14,3 +14,22 @@
 | DeepCSV (2017)        | BTV | Jan 9, 2020   | DeepCSV_94XSF_V4_B_F.csv           | SJBtag_SF.cc | [Twiki](https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation94X) |
 | DeepCSV (2018)        | BTV | Jan 9, 2020   | DeepCSV_102XSF_V1.csv              | SJBtag_SF.cc | [Twiki](https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation102X) |
 | Top tagging           | JME | Sept 22, 2020 | 201\*TopTaggingScaleFactors\*.root | None | [Twiki](https://twiki.cern.ch/twiki/bin/viewauth/CMS/JetTopTagging) [GitHub](https://github.com/cms-jet/TopTaggingScaleFactors) |
+
+## JEC/JES tarballs
+| Era    | Date added   | Files                                    | Sources |
+|--------|--------------|------------------------------------------|---------|
+| 2016   | Mar 18, 2021 | Summer16_07Aug2017*_V11_DATA(MC).tar.gz  | https://github.com/cms-jet/JRDatabase/tree/master/tarballs |
+| 2017   | Mar 18, 2021 | Fall17_17Nov2017*_V32_DATA(MC).tar.gz    | |
+| 2018   | Mar 18, 2021 | Autumn18*_V19_DATA(MC).tar.gz            | |
+| 2017UL | Mar 18, 2021 | Summer19UL17*_V5_DATA(MC).tar.gz         | |
+| 2018UL | Mar 18, 2021 | Summer19UL18*_V5_DATA(MC).tar.gz         | |
+
+## JER tarballs and files
+| Era    | Date added   | Files                             | Sources |
+|--------|--------------|-----------------------------------|---------|
+| 2016   | Mar 18, 2021 | Summer16_25nsV1b_DATA(MC).tar.gz  | https://github.com/cms-jet/JRDatabase/tree/master/tarballs |
+| 2017   | Mar 18, 2021 | Fall17_V3b_DATA(MC).tar.gz        | |
+| 2018   | Mar 18, 2021 | Autumn18_V7b_DATA(MC).tar.gz      | |
+| 2017UL | Mar 18, 2021 | Summer19UL17_JRV2_DATA(MC).tar.gz | |
+| 2018UL | Mar 18, 2021 | Summer19UL18_JRV2_DATA(MC).tar.gz | |
+| All    | Mar 18, 2021 | puppiSoftdropResol.root           | https://github.com/cms-jet/PuppiSoftdropMassCorrections/tree/80X/weights |

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,10 @@ setuptools.setup(
     include_package_data=True,
     # cmdclass={'install': AddToPath},
     install_requires = [
+        "decorator==4.4.2",
+        "pyparsing==2.4.7",
         "graphviz==0.14.2",
-        "pydot",
+        "pydot==1.4.1",
         "networkx==2.2",
         "clang==6.0.0.2"
     ]


### PR DESCRIPTION
# Change log
- Add JME data tarball information in readme
- Add W and top tagging scale factor modules (only tau21 and tau32+subjet btag supported, respectively)
- Update GenMatching tools to be better optimized and to take advantage of new AoS feature
- Return index from Pythonic::InList rather than a bool
- If ModuleWorker looks in a TIMBER .cc for a function (`eval` typically) and can't find it, look for it in the equivalent .h (since that's where templates live)