### PR TITLE
Simplify TopPt_weight, add CollectionOrganizer

### DIFF
--- a/TIMBER/Analyzer.py
+++ b/TIMBER/Analyzer.py
@@ -1010,14 +1010,14 @@ a.CalibrateVars(varCalibDict,evalArgs,"CorrectedFatJets")
 
 ```
         This will apply the JES and JER calibrations and their four variations (up,down pair for each) to FatJet_pt and FatJet_mass branches
-        and create a new collection called "CorrectedFatJets" which will be ordered by the new pt values. Note that if you want to correct a different
+        and create a new collection called "CalibratedFatJets" which will be ordered by the new pt values. Note that if you want to correct a different
         collection (ex. AK4 based Jet collection), you need a separate payload and separate call to CalibrateVars because only one collection can be generated at a time.
         Also note that in this example, `jes` and `jer` are initialized with the AK8PFPuppi jets in mind. So if you'd like to apply the JES or JER calibrations to
         AK4 jets, you would also need to define objects like `jesAK4` and `jerAK4`.
 
         The calibrations will always be calculated as a seperate
         column which stores a vector named `<CalibName>__vec` and ordered {nominal, up, down} where "up" and "down" are the absolute weights
-        (ie. not relative to "nominal"). If you'd just like the weights and do not want them applied to any variable, you can provide
+        (ie. "up" and "down" are not relative to "nominal"). If you'd just like the weights and do not want them applied to any variable, you can provide
         an empty dictionary (`{}`) for the varCalibDict argument.
         
         This method will set the new active node to the one with the new collection defined.

--- a/TIMBER/Analyzer.py
+++ b/TIMBER/Analyzer.py
@@ -94,20 +94,20 @@ class analyzer(object):
 
         super(analyzer, self).__init__()
         self.fileName = fileName 
-        self.__eventsTreeName = eventsTreeName
+        self._eventsTreeName = eventsTreeName
         self.silent = False
 
         # Setup TChains for multiple or single file
-        self.__eventsChain = ROOT.TChain(self.__eventsTreeName) 
+        self._eventsChain = ROOT.TChain(self._eventsTreeName) 
         self.RunChain = ROOT.TChain(runTreeName) 
         if isinstance(self.fileName,list):
             for f in self.fileName:
-                self.__addFile(f)
+                self._addFile(f)
         else:
-            self.__addFile(self.fileName)
+            self._addFile(self.fileName)
         
         # Make base RDataFrame
-        BaseDataFrame = ROOT.RDataFrame(self.__eventsChain) 
+        BaseDataFrame = ROOT.RDataFrame(self._eventsChain) 
         self.BaseNode = Node('base',BaseDataFrame) 
         self.BaseNode.children = [] # protect against memory issue when running over multiple sets in one script
         self.AllNodes = [self.BaseNode] 
@@ -133,7 +133,7 @@ class analyzer(object):
         # Get LHAID from LHEPdfWeights branch
         self.lhaid = "-1"
         if not self.isData:
-            pdfbranch = self.__eventsChain.GetBranch("LHEPdfWeight")
+            pdfbranch = self._eventsChain.GetBranch("LHEPdfWeight")
             if pdfbranch != None:
                 branch_title = pdfbranch.GetTitle()
                 if branch_title != '': 
@@ -164,7 +164,7 @@ class analyzer(object):
             if f.split('/')[-1] in skipHeaders: continue
             CompileCpp('#include "%s"\n'%f)
  
-    def __addFile(self,f):
+    def _addFile(self,f):
         '''Add file to TChains being tracked.
 
         Args:
@@ -173,13 +173,13 @@ class analyzer(object):
         if f.endswith(".root"): 
             if 'root://' not in f and f.startswith('/store/'):
                 f='root://cms-xrd-global.cern.ch/'+f
-            self.__eventsChain.Add(f)
+            self._eventsChain.Add(f)
             self.RunChain.Add(f)
         elif f.endswith(".txt"): 
             txt_file = open(f,"r")
             for l in txt_file.readlines():
                 thisfile = l.strip()
-                self.__addFile(thisfile)
+                self._addFile(thisfile)
         else:
             raise Exception("File name extension not supported. Please provide a single or list of .root files or a .txt file with a line-separated list of .root files to chain together.")
 
@@ -190,7 +190,7 @@ class analyzer(object):
             None
         '''
         self.BaseNode.Close()
-        self.__eventsChain.Reset()
+        self._eventsChain.Reset()
 
     def __str__(self):
         '''Call with `print(<analyzer>)` to print a nicely formatted description
@@ -751,7 +751,7 @@ class analyzer(object):
 
         return self.SetActiveNode(newNode)
 
-    def __checkCorrections(self,node,correctionNames,dropList):
+    def _checkCorrections(self,node,correctionNames,dropList):
         '''Starting at the provided node, will scale up the tree,
         grabbing all corrections added along the way. This ensures
         corrections from other forks of the analyzer tree are not
@@ -829,7 +829,7 @@ class analyzer(object):
         if name != '': namemod = '_'+name
         else: namemod = ''
 
-        correctionsToApply = self.__checkCorrections(node,correctionNames,dropList)
+        correctionsToApply = self._checkCorrections(node,correctionNames,dropList)
         
         # Build nominal weight first (only "weight", no "uncert")
         weights = {'nominal':''}
@@ -1078,7 +1078,7 @@ a.CalibrateVars(varCalibDict,evalArgs,"CorrectedFatJets")
         '''
         if node == None: node = self.ActiveNode
         # Type checking and create calibration branches
-        newNode = self.__checkCalibrations(node,varCalibDict,evalArgs)      
+        newNode = self._checkCalibrations(node,varCalibDict,evalArgs)      
         
         # Create the product of weights
         new_columns =  OrderedDict()
@@ -1111,7 +1111,7 @@ a.CalibrateVars(varCalibDict,evalArgs,"CorrectedFatJets")
 
         return self.SetActiveNode(newNode)
 
-    def __checkCalibrations(self,node,varCalibDict,evalArgs):
+    def _checkCalibrations(self,node,varCalibDict,evalArgs):
         newNode = node
         # Type checking
         if not isinstance(node,Node): raise TypeError('CalibrateVar() does not support argument of type %s for node. Please provide a Node.'%(type(node)))
@@ -1825,7 +1825,6 @@ class ModuleWorker(object):
         self._constructor = constructor 
         self._objectName = self.name
         self._call = None
-        # self.__funcNames = self.__funcInfo.keys()        
 
         if not isClone:
             if not self._mainFunc.endswith(mainFunc):

--- a/TIMBER/CollectionOrganizer.py
+++ b/TIMBER/CollectionOrganizer.py
@@ -1,0 +1,187 @@
+from TIMBER.Tools.Common import CompileCpp
+import re
+'''
+- Check for current handling of __collectionDict in Analyzer and replace with this
+- Replace instances of BuildCollectionDict and GetKeyValForBranch
+- Write ProcessLine
+- Implement ProcessLine in analyzer
+'''
+class CollectionOrganizer:
+    def __init__(self, rdf):
+        self.baseBranches = [str(b) for b in rdf.GetColumnNames()]
+        self.generateFromRDF(rdf)
+        self.builtCollections = []
+
+    def generateFromRDF(self, rdf):
+        self.collectionDict = {}
+        self.otherBranches = {}
+
+        for b in self.baseBranches:
+            self.AddBranch(b,rdf.GetColumnType(b))
+
+    def parsetype(self, t):
+        if not t.startswith('ROOT::VecOps::RVec<'):
+            collType = False
+        else:
+            collType = str(t).replace('ROOT::VecOps::RVec<','')
+            if collType.endswith('>'):
+                collType = collType[:-1]
+            collType += '&'
+            if 'Bool_t' in collType:
+                collType = collType.replace('Bool_t&','std::_Bit_reference')
+        
+        if collType == '&':
+            collType = ''
+        
+        return collType
+
+    def AddCollection(self, c):
+        if c not in self.collectionDict.keys():
+            self.collectionDict[c] = {'alias': False}
+
+    def GetCollectionAttributes(self, c):
+        return [c for c in self.collectionDict[c] if c != 'alias']
+
+    def AddBranch(self, b, btype=''):
+        collname = b.split('_')[0]
+        varname = '_'.join(b.split('_')[1:])
+        typeStr = self.parsetype(btype)
+        
+        if typeStr == False or varname == '' or 'n'+collname not in self.baseBranches:
+            self.otherBranches[b] = {
+                'type': typeStr,
+                'alias': False
+            }
+        elif varname != '':
+            self.AddCollection(collname)
+            self.collectionDict[collname][varname] = {
+                'type': typeStr,
+                'alias': False
+            }
+
+    def Alias(self, alias, name):
+        # Name is either in otherBranches, is a collection name, or is a full name <collection>_<attr>
+        if name in self.otherBranches.keys():
+            self.otherBranches[name]['alias'] = alias
+        elif name in self.collectionDict.keys():
+            self.collectionDict[name]['alias'] = alias
+        else:
+            collname = name.split('_')[0]
+            varname = '_'.join(name.split('_')[1:])
+            if collname in self.collectionDict.keys():
+                if varname in self.collectionDict[collname].keys():
+                    self.collectionDict[collname][varname]['alias'] = alias
+                else:
+                    raise ValueError('Cannot add alias `%s` because attribute `%s` does not exist in collection `%s`'%(alias,varname,collname))
+            else:
+                raise ValueError('Cannot add alias `%s` because collection `%s` does not exist'%(alias,collname))
+
+    def ProcessLine(self, line):
+        return line
+
+    def BuildCppCollection(self,collection,node,silent=True):
+        newNode = node
+        attributes = []
+        for aname in self.GetCollectionAttributes(collection):
+            attributes.append('%s %s'%(self.collectionDict[collection][aname]['type'], aname))
+
+        if collection+'s' not in self.builtCollections:
+            self.builtCollections.append(collection+'s')
+            CompileCpp(StructDef(collection,attributes))
+            newNode = newNode.Define(collection+'s', StructObj(collection,attributes),silent=silent)
+        else:
+            raise RuntimeError('Collections `%s` already built.'%(collection+'s'))
+
+        return newNode
+
+    def CollectionDefCheck(self, action_str, node):
+        newNode = node
+        for c in self.collectionDict.keys():
+            if re.search(r"\b" + re.escape(c+'s') + r"\b", action_str) and (c+'s' not in self.builtCollections):
+                print ('MAKING %ss for %s'%(c,action_str))
+                newNode = self.BuildCppCollection(c,newNode,silent=True)
+        return newNode
+
+#
+# Utilities already written
+#
+# def BuildCollectionDict(rdf, includeType = True):
+#     '''Turns a list of branches from an RDataFrame into a dictionary of collections.
+
+#     Args:
+#         rdf ([str]): RDataFrame from which to get the branches and types.
+#         includeType (bool, optional): Include the type in the stored variable name (prepended). Defaults to True.
+
+#     Returns:
+#         dict: Dictionary where key is collection name and value is list of variable names.
+#     '''
+#     collections = {}
+#     lone_branch = []
+
+#     branch_names = [str(b) for b in rdf.GetColumnNames()]
+#     for b in branch_names:
+#         collname, varname = GetKeyValForBranch(rdf, b, includeType)
+#         if varname == '' or 'n'+collname not in branch_names:
+#             lone_branch.append(collname)
+#         if collname not in collections.keys():
+#             collections[collname] = []
+#         collections[collname].append(varname)
+
+#     return collections,lone_branch
+
+# def GetKeyValForBranch(rdf, bname, includeType=True):
+#     collname = bname.split('_')[0]
+#     varname = '_'.join(bname.split('_')[1:])
+#     out = (collname, '')
+
+#     branch_names = [str(b) for b in rdf.GetColumnNames()]
+#     if varname == '' or 'n'+collname not in branch_names:
+#         pass
+#     elif varname != '':
+#         collType = str(rdf.GetColumnType(bname)).replace('ROOT::VecOps::RVec<','')
+#         if collType.endswith('>'): collType = collType[:-1]
+#         collType += '&'
+#         if 'Bool_t' in collType: collType = collType.replace('Bool_t&','std::_Bit_reference')
+#         if includeType:
+#             out = (collname, collType+' '+varname)
+#         else:
+#             out = (collname, collType+' '+varname)
+
+#     return out
+
+def StructDef(collectionName, varList):
+    out_str = '''
+struct {0}Struct {{
+        {1}
+        {0}Struct({2}) :
+        {3} {{
+        }};
+}};
+    '''
+    definitions = []
+    ctor_args = []
+    ctor_assign = []
+    for i,v in enumerate(varList):
+        definitions.append('%s; \n'%v)
+        ctor_args.append('%s'%v)
+        ctor_assign.append('%s(%s)'%(v.split(' ')[-1], v.split(' ')[-1]))
+
+    out_str = out_str.format(collectionName, '\t'.join(definitions), ','.join(ctor_args),','.join(ctor_assign))
+    return out_str
+
+def StructObj(collectionName, varList):
+    out_str = '''
+std::vector<{0}Struct> {0}s;
+{0}s.reserve(n{0});
+for (size_t i = 0; i < n{0}; i++) {{
+    {0}s.emplace_back({1});
+}}
+return {0}s;
+'''
+    attr_assignment_str = ''
+    print (varList)
+    for i,v in enumerate(varList):
+        varname = v.split(' ')[-1]
+        attr_assignment_str += '{0}_{1}[i],'.format(collectionName, varname)
+    out_str = out_str.format(collectionName,attr_assignment_str[:-1])
+    return out_str

--- a/TIMBER/Framework/include/TopPt_weight.h
+++ b/TIMBER/Framework/include/TopPt_weight.h
@@ -15,11 +15,9 @@ using namespace ROOT::VecOps;
  * 
  * \f[ \sqrt{e^{\alpha - \beta \cdot p_{T}^{\textrm{Gen} t}} \cdot e^{\alpha - \beta \cdot p_{T}^{\textrm{Gen} \bar{t}} }} \f].
  * 
- * where \f$\alpha = 0.0615\f$ and \f$\beta = 0.0005\f$. See the alpha() and beta() functions
- * to calculate the weights with these parameters varied.
- * 
- * WARNING: You MUST run corr() before alpha() and beta() since these functions
- * recycle information derived from corr().
+ * where \f$\alpha = 0.0615\f$ and \f$\beta = 0.0005\f$. See the eval() function
+ * to calculate the weight plus variations of the \f$\beta\f$ parameter. The \f$\alpha\f$ parameter
+ * is not varied since it would only represent a flat normalization change.
  * 
  */
 class TopPt_weight {
@@ -28,48 +26,19 @@ class TopPt_weight {
                 ROOT::Math::PtEtaPhiMVector jet0, ROOT::Math::PtEtaPhiMVector jet1);
 
     public:
-        TopPt_weight(){};
+        /**
+         * @brief Construct a new TopPt_weight object. No arguments.
+         * 
+         */
+        TopPt_weight();
         ~TopPt_weight(){};
         /**
          * @brief Calculate the top \f$p_T\f$ reweighting value for \f$t\bar{t}\f$ simulation
-         * based on doing gen particle matching. The weight is calculated as 
-         * \f[ \sqrt{e^{\alpha - \beta \cdot p_{T}^{\textrm{Gen } t}} \cdot e^{\alpha - \beta \cdot p_{T}^{\textrm{Gen } \bar{t}} }} \f].
-         * where \f$\alpha = 0.0615\f$ and \f$\beta = 0.0005\f$. See the alpha() and beta() functions
-         * to calculate the weights with these parameters varied.
-         * 
-         * @param GenPart_pdgId NanoAOD branch
-         * @param GenPart_statusFlags NanoAOD branch
-         * @param GenPart_vects Vector of ROOT::Math::PtEtaPhiMVectors (create through hardware::TLvector)
-         * @param jet0 
-         * @param jet1 
-         * @return RVec<float> Will only be length 1. Stored as vector to satisfy TIMBER Correction() requirements
-         */
-        RVec<float> corr(RVec<int> GenPart_pdgId, RVec<int> GenPart_statusFlags, RVec<ROOT::Math::PtEtaPhiMVector> GenPart_vects,
-                ROOT::Math::PtEtaPhiMVector jet0, ROOT::Math::PtEtaPhiMVector jet1);
-        /**
-         * @brief Calculate variations of top \f$p_T\f$ weight by varying the \f$\alpha\f$ parameter.
+         * based on doing gen particle matching. Additionally, calculate variations of the top
+         * \f$p_T\f$ weight by varying the \f$\beta\f$ parameter.
          * The amount of variation can be changed via the scale arguement which is a 
-         * percent change on \f$\alpha\f$. The output is the weight calculated with the variation
-         * divided by the nominal value. When using MakeWeightCols(), the nominal will be multiplied
-         * by this variation to recover the total weight.
-         * 
-         * @param GenPart_pdgId NanoAOD branch
-         * @param GenPart_statusFlags NanoAOD branch
-         * @param GenPart_vects Vector of ROOT::Math::PtEtaPhiMVectors (create through hardware::TLvector)
-         * @param jet0 
-         * @param jet1 
-         * @param scale Percent variation on \f$\alpha\f$ parameter.
-         * @return RVec<float> {up, down} variations of the top \f$p_T\f$ reweighting value divided by the nominal weight.
-         */
-        RVec<float> alpha(
-                RVec<int> GenPart_pdgId, RVec<int> GenPart_statusFlags, RVec<ROOT::Math::PtEtaPhiMVector> GenPart_vects,
-                ROOT::Math::PtEtaPhiMVector jet0, ROOT::Math::PtEtaPhiMVector jet1, float scale = 0.5);
-        /**
-         * @brief Calculate variations of the top \f$p_T\f$ weight by varying the \f$\beta\f$ parameter.
-         * The amount of variation can be changed via the scale arguement which is a 
-         * percent change on \f$\beta\f$. The output is the weight calculated with the variation
-         * divided by the nominal value. When using MakeWeightCols(), the nominal will be multiplied
-         * by this variation to recover the total weight.
+         * percent change on \f$\beta\f$. There is no corresponding function for \f$\alpha\f$
+         * because the effect is only a flat normalization change.
          * 
          * @param GenPart_pdgId NanoAOD branch
          * @param GenPart_statusFlags NanoAOD branch
@@ -77,9 +46,9 @@ class TopPt_weight {
          * @param jet0 
          * @param jet1 
          * @param scale Percent variation on \f$\beta\f$ parameter.
-         * @return RVec<float> {up, down} variations of the top \f$p_T\f$ reweighting value divided by the nominal weight.
+         * @return RVec<float> {nom, up, down} variations of the top \f$p_T\f$ reweighting value (absolute).
          */
-        RVec<float> beta(
+        RVec<float> eval(
                 RVec<int> GenPart_pdgId, RVec<int> GenPart_statusFlags, RVec<ROOT::Math::PtEtaPhiMVector> GenPart_vects,
                 ROOT::Math::PtEtaPhiMVector jet0, ROOT::Math::PtEtaPhiMVector jet1, float scale = 0.5);
 };

--- a/TIMBER/Framework/src/TopPt_weight.cc
+++ b/TIMBER/Framework/src/TopPt_weight.cc
@@ -1,5 +1,7 @@
 #include "../include/TopPt_weight.h"
 
+TopPt_weight::TopPt_weight(){};
+
 std::vector<float> TopPt_weight::matchingGenPt(
         RVec<int> GenPart_pdgId, RVec<int> GenPart_statusFlags, RVec<ROOT::Math::PtEtaPhiMVector> GenPart_vects,
         ROOT::Math::PtEtaPhiMVector jet0, ROOT::Math::PtEtaPhiMVector jet1){
@@ -24,9 +26,9 @@ std::vector<float> TopPt_weight::matchingGenPt(
     return {genTPt,genTbarPt};
 }
 
-RVec<float> TopPt_weight::corr(
+RVec<float> TopPt_weight::eval(
         RVec<int> GenPart_pdgId, RVec<int> GenPart_statusFlags, RVec<ROOT::Math::PtEtaPhiMVector> GenPart_vects,
-        ROOT::Math::PtEtaPhiMVector jet0, ROOT::Math::PtEtaPhiMVector jet1) {
+        ROOT::Math::PtEtaPhiMVector jet0, ROOT::Math::PtEtaPhiMVector jet1, float scale){
 
     std::vector<float> matched = matchingGenPt(GenPart_pdgId, GenPart_statusFlags,
                                           GenPart_vects, jet0, jet1);
@@ -34,66 +36,22 @@ RVec<float> TopPt_weight::corr(
     float genTbarPt = matched[1];
 
     float wTPt = 1.0;
+    float wTPt_up = 1.0;
+    float wTPt_down = 1.0;
     if (genTPt > 0){ 
         wTPt = exp(0.0615 - 0.0005*genTPt);
+        wTPt_up = exp((1+scale)*0.0615 - 0.0005*genTPt);
+        wTPt_down = exp((1-scale)*0.0615 - 0.0005*genTPt);
     }
 
     float wTbarPt = 1.0;
-    if (genTbarPt > 0){ 
+    float wTbarPt_up = 1.0;
+    float wTbarPt_down = 1.0;
+    if (genTbarPt > 0){
         wTbarPt = exp(0.0615 - 0.0005*genTbarPt);
+        wTbarPt_up = exp((1+scale)*0.0615 - 0.0005*genTbarPt);
+        wTbarPt_down = exp((1-scale)*0.0615 - 0.0005*genTbarPt);
     }
 
-    return {sqrt(wTPt*wTbarPt)};
-}
-
-RVec<float> TopPt_weight::alpha(
-        RVec<int> GenPart_pdgId, RVec<int> GenPart_statusFlags, RVec<ROOT::Math::PtEtaPhiMVector> GenPart_vects,
-        ROOT::Math::PtEtaPhiMVector jet0, ROOT::Math::PtEtaPhiMVector jet1, float scale){
-
-    std::vector<float> matched = matchingGenPt(GenPart_pdgId, GenPart_statusFlags,
-                                          GenPart_vects, jet0, jet1);
-    float genTPt = matched[0];
-    float genTbarPt = matched[1];
-
-    float wTPt_up = 1.0;
-    float wTPt_down = 1.0;
-    if (genTPt > 0){ 
-        wTPt_up = exp((1+scale)*0.0615 - 0.0005*genTPt) / exp(0.0615 - 0.0005*genTPt);
-        wTPt_down = exp((1-scale)*0.0615 - 0.0005*genTPt) / exp(0.0615 - 0.0005*genTPt);
-    }
-
-    float wTbarPt_up = 1.0;
-    float wTbarPt_down = 1.0;
-    if (genTbarPt > 0){ 
-        wTbarPt_up = exp((1+scale)*0.0615 - 0.0005*genTbarPt) / exp(0.0615 - 0.0005*genTbarPt);
-        wTbarPt_down = exp((1-scale)*0.0615 - 0.0005*genTbarPt) / exp(0.0615 - 0.0005*genTbarPt);
-    }
-
-    return {sqrt(wTPt_up*wTbarPt_up),sqrt(wTPt_down*wTbarPt_down)};
-}
-
-RVec<float> TopPt_weight::beta(
-        RVec<int> GenPart_pdgId, RVec<int> GenPart_statusFlags, RVec<ROOT::Math::PtEtaPhiMVector> GenPart_vects,
-        ROOT::Math::PtEtaPhiMVector jet0, ROOT::Math::PtEtaPhiMVector jet1, float scale){
-
-    std::vector<float> matched = matchingGenPt(GenPart_pdgId, GenPart_statusFlags,
-                                          GenPart_vects, jet0, jet1);
-    float genTPt = matched[0];
-    float genTbarPt = matched[1];
-
-    float wTPt_up = 1.0;
-    float wTPt_down = 1.0;
-    if (genTPt > 0){ 
-        wTPt_up = exp(0.0615 - (1+scale)*0.0005*genTPt) / exp(0.0615 - 0.0005*genTPt);
-        wTPt_down = exp(0.0615 - (1-scale)*0.0005*genTPt) / exp(0.0615 - 0.0005*genTPt);
-    }
-
-    float wTbarPt_up = 1.0;
-    float wTbarPt_down = 1.0;
-    if (genTbarPt > 0){ 
-        wTbarPt_up = exp(0.0615 - (1+scale)*0.0005*genTbarPt) / exp(0.0615 - 0.0005*genTbarPt);
-        wTbarPt_down = exp(0.0615 - (1-scale)*0.0005*genTbarPt) / exp(0.0615 - 0.0005*genTbarPt);
-    }
-
-    return {sqrt(wTPt_up*wTbarPt_up),sqrt(wTPt_down*wTbarPt_down)};
+    return {sqrt(wTPt*wTbarPt),sqrt(wTPt_up*wTbarPt_up),sqrt(wTPt_down*wTbarPt_down)};
 }

--- a/test/test_Analyzer.py
+++ b/test/test_Analyzer.py
@@ -20,7 +20,7 @@ class TestAnalyzer():
 
     def test_lhaid_None(self):
         '''Test lhaid is assigned 0 when branch doesn't exist in test file'''
-        assert self.a.lhaid == '-1'
+        assert self.a.lhaid == -1
 
     def test_GetTrackedNodeNames(self):
         '''Test GetTrackNodeNames method after adding a node'''

--- a/test/test_Analyzer.py
+++ b/test/test_Analyzer.py
@@ -97,6 +97,9 @@ class TestAnalyzer():
         assert self.a.GetFlagString(['HLT_IsoMu24','HLT_IsoMu24_eta2p1','NotReal']) == '((HLT_IsoMu24==1) && (HLT_IsoMu24_eta2p1==1))'
         pass
 
+    def test_CollectionStruct(self):
+        self.a.Cut('structCut','Jets[0].pt > 0')
+
 def test_Groups():
     a = analyzer('examples/GluGluToHToTauTau.root')
     # CompileCpp('TIMBER/Framework/include/common.h') # Compile (via gInterpreter) commonly used c++ code
@@ -113,3 +116,7 @@ def test_Groups():
     a.Apply([test_vg, test_cg])
     rep = a.DataFrame.Report()
     rep.Print()
+
+def test_CollectionGroup():
+    a = analyzer('examples/GluGluToHToTauTau.root')
+    assert ('Jet' in a.GetCollectionNames())


### PR DESCRIPTION
# Change log
- Change Tpt weight module to drop alpha variation since it's only a normalization effect. Switch the `beta` class method to `eval` and drop `corr` (`eval` now does the nominal and variations).
- Change `__` prefix on private variables to `_` for consistency.
- Create CollectionOrganizer and implement it. Does not create any user-facing changes but provides infrastructure for future features.