### PR TITLE
Undesired (?) setup script behavior

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -7,8 +7,8 @@ fi
 
 if ! command -v dot &> /dev/null
 then
-  echo "dot (graphviz) could not be found. Please install it first... (on Ubuntu `sudo apt-get install graphviz libgraphviz-dev`)"
-  exit
+  echo "dot (graphviz) could not be found. Please install it first... (on Ubuntu 'sudo apt-get install graphviz libgraphviz-dev')"
+  return
 fi
 
 python setup.py install


### PR DESCRIPTION
This is just something I noticed the other day when setting up the framework. The graphviz installation suggestion was enclosed with backticks, meaning that the command `sudo apt-get install graphviz libgraphviz-dev` would attempt to be executed when sourcing the script, with all its output being directed to `/dev/null`. Also, when using `source` to run the shell script, the `exit` command acts to close the entire terminal window - `return` just exits the script and keeps the active window. If this is intended, please feel free to ignore!