### PR TITLE
Multigridpack compatibility

### DIFF
--- a/TIMBER/Analyzer.py
+++ b/TIMBER/Analyzer.py
@@ -100,7 +100,7 @@ class analyzer(object):
         self.silent = False
         if multiSampleStr != '':
             multiSampleStr = 'YMass_%s'%multiSampleStr
-            genEventSumw_str = 'genEventSumw_'+multiSampleStr
+        genEventSumw_str = 'genEventSumw_'+multiSampleStr
 
         # Setup TChains for multiple or single file
         self._eventsChain = ROOT.TChain(self._eventsTreeName) 

--- a/TIMBER/CollectionOrganizer.py
+++ b/TIMBER/CollectionOrganizer.py
@@ -26,6 +26,7 @@ class CollectionOrganizer:
         self._otherBranches = {}
 
         for b in self._baseBranches:
+            if 'fCoordinates' in b: continue
             self.AddBranch(b,rdf.GetColumnType(b))
 
     def _parsetype(self, t):

--- a/setup.csh
+++ b/setup.csh
@@ -9,7 +9,7 @@ if (`command -v dot` == "") then
   return
 endif
 
-# python setup.py install
+python setup.py develop
 set activate_path=$VIRTUAL_ENV/bin/activate.csh
 setenv TIMBERPATH "$PWD/"
 

--- a/setup.sh
+++ b/setup.sh
@@ -11,7 +11,7 @@ then
   return
 fi
 
-python setup.py install
+python setup.py develop
 activate_path=$VIRTUAL_ENV/bin/activate
 export TIMBERPATH="$PWD/"
 


### PR DESCRIPTION
Add `multiSampleStr` optional argument to `analyzer()` so that multi-gridpack generated samples can be accommodated.

Make "develop" the default setup mode since fixes are becoming regular.