### PR TITLE
Snapshot openOption fix

### DIFF
--- a/TIMBER/Analyzer.py
+++ b/TIMBER/Analyzer.py
@@ -71,6 +71,10 @@ class analyzer(object):
         # int
         #
         # Sum of weights of generated events in imported simulation files. Zero if not found or data.
+        ## @var genEventCount
+        # int
+        #
+        # Number of generated events in imported simulation files. Zero if not found or data.
         ## @var lhaid
         # int
         #
@@ -96,6 +100,7 @@ class analyzer(object):
         if multiSampleStr != '':
             multiSampleStr = 'YMass_%s'%multiSampleStr
         genEventSumw_str = 'genEventSumw_'+multiSampleStr
+        genEventCount_str = 'genEventCount_'+multiSampleStr
 
         # Setup TChains for multiple or single file
         self._eventsChain = ROOT.TChain(self._eventsTreeName) 
@@ -122,13 +127,16 @@ class analyzer(object):
  
         # Count number of generated events if not data
         self.genEventSumw = 0.0
+        self.genEventCount = 0
         if not self.isData: 
             for i in range(self.RunChain.GetEntries()): 
                 self.RunChain.GetEntry(i)
                 if hasattr(self.RunChain,'genEventSumw'):
                     self.genEventSumw+= self.RunChain.genEventSumw
+                    self.genEventCount+= self.RunChain.genEventCount
                 elif hasattr(self.RunChain,genEventSumw_str):
                     self.genEventSumw+= getattr(self.RunChain,genEventSumw_str)
+                    self.genEventCount+= getattr(self.RunChain,genEventCount_str)
                 else:
                     raise NameError('In attempt to deduce sum of event weights, could not access branch genEventSumw or %s in TTree %s.'%(genEventSumw_str,self._runTreeName))
 

--- a/TIMBER/Analyzer.py
+++ b/TIMBER/Analyzer.py
@@ -231,11 +231,24 @@ class analyzer(object):
         return self.ActiveNode.DataFrame
 
     def Snapshot(self,columns,outfilename,treename,lazy=False,openOption='UPDATE',saveRunChain=True):
-        '''@see Node#Snapshot'''
+        '''@see Node#Snapshot for full description.
+
+        @param columns ([str] or str): List of columns to keep (str) with regex matching.
+                Provide single string 'all' to include all columns.
+        @param outfilename (str): Name of the output file
+        @param treename ([type]): Name of the output TTree
+        @param lazy (bool, optional): If False, the RDataFrame actions until this point will be executed here. Defaults to False.
+        @param openOption (str, optional): TFile opening options. Defaults to 'RECREATE'.
+        @param saveRunChain (bool, optional): Whether to save the TTree specified by runTreeName with the snapshot. Defaults to True.
+
+        Returns:
+            None
+        '''
         if saveRunChain:
+            if openOption != 'RECREATE':
+                raise ValueError('Cannot %s file while also saving Runs TTree. Change openOption to RECREATE.'%openOption)
             self.SaveRunChain(outfilename,merge=False)
-        elif saveRunChain == False and openOption == 'UPDATE':
-            openOption = 'RECREATE'
+            openOption = 'UPDATE' # switch option so snapshot can be saved with RunChain file
         self.ActiveNode.Snapshot(columns,outfilename,treename,lazy,openOption)
 
     def SaveRunChain(self,filename,merge=True):

--- a/TIMBER/Analyzer.py
+++ b/TIMBER/Analyzer.py
@@ -123,6 +123,9 @@ class analyzer(object):
             self.preV6 = True 
         elif hasattr(self.RunChain,genEventSumw_str): 
             self.preV6 = False
+        else:
+            raise NameError('In attempt to deduce NanoAOD version, could not access branch genEventSumw or %s in TTree %s.'%(genEventSumw_str,self._runTreeName))
+
         # Check if dealing with data
         if hasattr(self._eventsChain,'genWeight'):
             self.isData = False


### PR DESCRIPTION
### Issue
Using option "RECREATE" would overwrite the file with the Runs TTree, even when saveRunChain was set to True.

This PR also adds a descriptive exception in the case where self.preV6 can't be determined from the NanoAOD Runs TTree but the TTree exists.